### PR TITLE
feat(posts,search): stored posts.domain + word-level fuzzy post search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 This run took the PoC from a rough, non-booting prototype to a running,
 test-covered Reddit clone. Highlights, newest first:
 
+### Stored `posts.domain` + sqlean `fuzzy`/`regexp` put to work
+- **`posts.domain` is now a real, indexed column** (migration `[108]`), the
+  normalized link host computed once at write time by `Posts:create` (via
+  `utils/url`'s socket.url parser) and backfilled for existing rows. This
+  replaces recomputing the host in Lua on every listing read **and fixes the
+  `/domain/:host` filter**, which was a substring `url LIKE '%host%'` that
+  wrongly matched `notexample.com` and `?ref=host`; it is now an exact match.
+  The `GENERATED ALWAYS AS (...)` form was evaluated and declined — socket.url
+  parses hosts better than any SQL regex, and an extension-backed generated
+  column faults every INSERT/SELECT on a connection without the sqlean `.so`
+  (the test suite, `lapis migrate`).
+- **Typo-tolerant post search.** When the FTS5 query returns nothing and the
+  sqlean bundle is loaded, `Posts:search` falls back to a word-level fuzzy pass
+  (`regexp_replace` to normalize + split titles, `jaro_winkler ≥ 0.85` per word)
+  so "programing" still finds "…programming…". FTS5 stays the default; the
+  fallback only widens an empty result, so behaviour is unchanged without the
+  extension. Complements the existing fuzzy **subreddit** search.
+- **sqlean module evaluation finalized** (`docs/sqlean-plan.md`): `fuzzy` and a
+  light touch of `regexp` adopted; `crypto` dropped (tokens use `openssl.rand`);
+  `text`/`stats`/`math` left in Lua; `uuid` deferred to the API phase. Verified
+  against the bundled `0.28.3` `.so` that it exposes the unprefixed aliases
+  (`jaro_winkler`, `dlevenshtein`, `regexp_replace`) the code relies on.
+
 ### UI clean slate: new CSS + Datastar, drop the vendored Reddit front-end
 - **New classless stylesheet** — replaced the 14k-line vendored `saidit.css`
   (plus `compact`/`highlight`/`mobile` and the `.less`/`.scss` soup) with a single

--- a/TODO.md
+++ b/TODO.md
@@ -170,29 +170,36 @@ dependency-driven (foundations first); full plan in
       and the FK/partial indexes above already serve the hot path. The dead
       `v_hot_*` / `v_forum` views have now been **removed** (see code-comments
       section).
-- [ ] Generated column for `posts.domain` (`GENERATED ALWAYS AS
-      (url_host(url))`) instead of computing it in Lua — needs a host-extract
-      SQL function (sqlean `regexp`/`define`, below).
-- [ ] **sqlean** extensions — evaluated module-by-module
-      (<https://github.com/nalgeon/sqlean>); see **`docs/sqlean-plan.md`** for
-      the concrete integration plan (verified that `lsqlite3:load_extension`
-      works at the C-API level; a `lsqlite3.open` wrapper in `init_by_lua` is
-      the per-connection hook; `crypto` is unnecessary since `hex(randomblob())`
-      is built-in). All require per-platform `.so`s bundled in the image, so
-      they're a single future infra task. Per-module verdict:
-  - `regexp` — **useful**: `regexp_substr(url, ...)` to extract `posts.domain`
-    host in SQL (feeds the generated column above) + content normalization.
-  - `fuzzy` — **useful**: `dlevenshtein`/`soundex` for typo-tolerant search
-    ranking on top of FTS5.
-  - `crypto` — **not needed**: the only planned consumer was the password-reset
-    flow, which now ships using `openssl.rand` for its tokens (see migration
-    `[17]` / `models/password_resets`).
-  - `text` — **minor**: `text_substring`/`split` helpers; mostly doable in Lua.
-  - `stats` / `math` — **minor**: could move the `hot`/`rising` score math into
-    SQL ranking, but `sort.lua` already does it; revisit if sorting becomes a
-    bottleneck.
-  - `uuid` — **maybe**: stable external ids for the future API phase.
-  - `define` — **maybe**: wrap the `url_host` logic as a reusable SQL function.
+- [x] **Stored `posts.domain`** — a normalized link host is now a real column
+      (migration `[108]`), populated once at write time by `Posts:create` (via
+      `utils/url`'s socket.url parser) and backfilled for existing rows. The
+      `GENERATED ALWAYS AS (...)` form was **evaluated and declined**: socket.url
+      parses hosts more correctly than any SQL regex, and an extension-backed
+      generated column faults every INSERT (STORED) or SELECT (VIRTUAL) on a
+      connection without the sqlean `.so` loaded — i.e. the test suite and
+      `lapis migrate`. The stored column also fixes the `/domain/:host` filter,
+      which was a substring `url LIKE '%host%'` that conflated `notexample.com`
+      and `?ref=host`; it is now an exact, indexed match.
+- [x] **sqlean** extensions — the bundle (`/usr/local/lib/sqlite/sqlean.so`,
+      pinned `0.28.3` in the Dockerfile) is loaded into Lapis's live connection
+      per worker by `src/utils/sqlite_ext.lua`; see **`docs/sqlean-plan.md`** for
+      the final per-module decisions. Confirmed against the actual `.so` that the
+      bundle exposes both the unprefixed aliases (`jaro_winkler`, `dlevenshtein`,
+      `regexp_replace`, …) and the `fuzzy_*` names. Per-module verdict:
+  - `fuzzy` — **adopted**: `jaro_winkler` powers typo-tolerant **subreddit
+    search** (`Forum:search`) and a word-level **post-search fallback**
+    (`Posts:search` → `fuzzy_title_search`, used only when FTS5 finds nothing).
+  - `regexp` — **adopted (light)**: `regexp_replace` normalizes punctuation when
+    splitting titles into words for the fuzzy post-search fallback. Not used for
+    `posts.domain` — socket.url parses hosts more correctly (see above).
+  - `crypto` — **not needed**: secure tokens use `openssl.rand` (migration `[17]`
+    / `models/password_resets`); `hex(randomblob())` covers the rest.
+  - `text` — **not adopted**: `text_substring`/`split` are doable in Lua.
+  - `stats` / `math` — **not adopted**: `hot`/`rising` math stays in `sort.lua`;
+    revisit if SQL-side ranking becomes a bottleneck.
+  - `uuid` — **deferred to the API phase**: stable external ids.
+  - `define` — **not adopted**: no reusable SQL function needed once the
+    `url_host` generated column was dropped.
   - `ipaddr`, `vsv`, `unicode`, `time`, `besttype` — **not needed** for this
     workload.
 

--- a/app/migrations.lua
+++ b/app/migrations.lua
@@ -179,7 +179,13 @@ return {
 
 			{ "title", types.text },
 			{ "url", types.text({ null = true }) }, -- null for self/text posts
-			-- { "domain", types.TEXT, "GENERATED ALWAYS AS (url_host(url)) VIRTUAL"},
+			-- The normalized link host lives in `domain` (added in migration [108],
+			-- populated in Lua by Posts:create via utils/url). A generated column
+			-- GENERATED ALWAYS AS (regexp_substr(url, ...)) was evaluated and
+			-- declined: socket.url parses hosts more correctly than any SQL regex,
+			-- and an extension-backed generated column would fault every INSERT
+			-- (STORED) or SELECT (VIRTUAL) on a connection without the sqlean .so
+			-- loaded -- i.e. the test suite and `lapis migrate`. See docs/sqlean-plan.md.
 			{ "created_at", types.text },
 			{ "updated_at", types.text },
 
@@ -828,6 +834,30 @@ return {
 			"UNIQUE(provider, provider_user_id)",
 		}, opts)
 		schema.create_index("oauth_identities", "user_id", { if_not_exists = true })
+	end,
+
+	-- Stored, normalized link host for posts. Replaces computing the domain in
+	-- Lua on every listing read and the buggy substring `url LIKE '%host%'`
+	-- domain filter (which matched notexample.com / ?ref=host) with an exact,
+	-- indexed match. Populated by Posts:create (utils/url, socket.url-backed);
+	-- backfilled here for existing link posts. Self/relative posts keep NULL.
+	[108] = function()
+		local Url = require("src.utils.url")
+		local has_col = false
+		for _, c in ipairs(db.query("PRAGMA table_info(posts)")) do
+			if c.name == "domain" then
+				has_col = true
+			end
+		end
+		if not has_col then
+			schema.add_column("posts", "domain", types.text({ null = true }))
+		end
+		schema.create_index("posts", "domain", { if_not_exists = true })
+		-- Backfill is idempotent: recomputing the same host is harmless.
+		for _, p in ipairs(db.select("id, url FROM posts WHERE url IS NOT NULL AND url != ''")) do
+			local d = Url.domain(p.url)
+			db.update("posts", { domain = d ~= "" and d or db.NULL }, { id = p.id })
+		end
 	end,
 
 	-- classify text : https://github.com/leafo/lapis-bayes

--- a/app/spec/models_spec.lua
+++ b/app/spec/models_spec.lua
@@ -183,6 +183,67 @@ describe("pagesix models", function()
 		assert.same("github.com", gh[1].domain)
 	end)
 
+	it("stores the normalized host on create and matches it exactly", function()
+		local user = make_user("ivan")
+		local sub = Forum:create({ name = "exactdomains", creator_id = user.id })
+		-- Posts:create stamps posts.domain from the url (www stripped, lowercased).
+		Posts:create({
+			user_id = user.id,
+			sub_id = sub.id,
+			title = "real example",
+			url = "https://www.Example.com/page",
+		})
+		-- A different host that merely *contains* "example.com" as a substring:
+		-- the old `url LIKE '%example.com%'` filter wrongly matched these.
+		Posts:create({
+			user_id = user.id,
+			sub_id = sub.id,
+			title = "look-alike host",
+			url = "https://notexample.com/x",
+		})
+		Posts:create({
+			user_id = user.id,
+			sub_id = sub.id,
+			title = "host in query string",
+			url = "https://tracker.test/r?ref=example.com",
+		})
+		-- A self post (no url) stores no domain.
+		Posts:create({
+			user_id = user.id,
+			sub_id = sub.id,
+			title = "just text",
+			body = "no link here",
+			is_self = 1,
+		})
+
+		local hits = Posts:get_listing({ sub_id = sub.id, domain = "example.com" })
+		assert.same(1, #hits)
+		assert.same("real example", hits[1].title)
+		assert.same("example.com", hits[1].domain)
+	end)
+
+	it("migration [108] backfills domain for rows missing it", function()
+		local db = require("lapis.db")
+		local migrations = require("migrations")
+		local user = make_user("judy")
+		local sub = Forum:create({ name = "backfilltest", creator_id = user.id })
+		local post = Posts:create({
+			user_id = user.id,
+			sub_id = sub.id,
+			title = "bf",
+			url = "https://Backfill.Example/x",
+		})
+		-- Simulate a pre-migration row whose host was never stored.
+		db.update("posts", { domain = db.NULL }, { id = post.id })
+		assert.is_nil(db.select("domain FROM posts WHERE id = ?", post.id)[1].domain)
+		-- Re-running the (idempotent) migration re-derives the normalized host.
+		migrations[108]()
+		assert.same(
+			"backfill.example",
+			db.select("domain FROM posts WHERE id = ?", post.id)[1].domain
+		)
+	end)
+
 	it("Sort orders by 'top' and tolerates rows missing vote fields", function()
 		local rows = {
 			{ id = 1, upvotes = 1, downvotes = 0 },

--- a/app/spec/posts_search_spec.lua
+++ b/app/spec/posts_search_spec.lua
@@ -1,0 +1,70 @@
+--- Post search spec
+-- Exercises Posts:search. The FTS5 path (exact/token matching) holds
+-- everywhere; the typo-tolerant fallback needs sqlean's fuzzy extension
+-- (present in the production Docker image / `docker` CI job) so it marks itself
+-- pending where the bundle isn't installed.
+
+local use_test_env = require("lapis.spec").use_test_env
+local Posts = require("src.models.posts")
+local Forum = require("src.models.forum")
+local Users = require("models.users")
+
+local function file_exists(path)
+	local f = io.open(path, "rb")
+	if f then
+		f:close()
+		return true
+	end
+	return false
+end
+
+local function titles_of(rows)
+	local set = {}
+	for _, r in ipairs(rows) do
+		set[r.title] = true
+	end
+	return set
+end
+
+describe("Posts:search", function()
+	use_test_env()
+
+	-- Mirrors sqlite_ext's own default-path resolution.
+	local have_fuzzy =
+		file_exists(os.getenv("SQLITE_EXTENSIONS") or "/usr/local/lib/sqlite/sqlean.so")
+
+	setup(function()
+		require("spec.schema_helper")()
+		local author = Users:create({
+			user_name = "search_author",
+			user_pass = "password",
+			user_email = "search_author@example.com",
+		})
+		local sub = Forum:create({ name = "searchsub", creator_id = author.id })
+		for _, title in ipairs({ "Functional programming in Lua", "Gardening tips" }) do
+			Posts:create({ user_id = author.id, sub_id = sub.id, title = title })
+		end
+	end)
+
+	it("returns nothing for a blank query", function()
+		assert.same({}, Posts:search(""))
+		assert.same({}, Posts:search(nil))
+	end)
+
+	it("finds a post via the FTS5 index", function()
+		assert.truthy(titles_of(Posts:search("programming"))["Functional programming in Lua"])
+		assert.is_nil(titles_of(Posts:search("programming"))["Gardening tips"])
+	end)
+
+	it("falls back to fuzzy matching on a typo when the extension is available", function()
+		if not have_fuzzy then
+			pending("sqlean fuzzy extension not installed in this environment")
+			return
+		end
+		-- "programing" (a dropped m) is not an FTS5 term match, so only the
+		-- word-level Jaro-Winkler fallback over titles can surface the post.
+		assert.truthy(titles_of(Posts:search("programing"))["Functional programming in Lua"])
+		-- A genuine non-match still returns nothing (no wild fuzzy matches).
+		assert.same({}, Posts:search("xyzzyqwerty"))
+	end)
+end)

--- a/app/spec/schema_helper.lua
+++ b/app/spec/schema_helper.lua
@@ -30,6 +30,7 @@ return function()
 		105,
 		106,
 		107,
+		108,
 	}) do
 		if migrations[k] then
 			migrations[k]()

--- a/app/src/actions/domain.lua
+++ b/app/src/actions/domain.lua
@@ -5,7 +5,9 @@ local Posts = require("models.posts")
 
 return {
 	before = function(self)
-		self.domain = self.params.domain or ""
+		-- Normalize to match the stored host (lowercased, leading www. stripped)
+		-- so a hand-typed /domain/WWW.Example.com still resolves.
+		self.domain = (self.params.domain or ""):lower():gsub("^www%.", "")
 
 		-- A bare word with no dot isn't a domain; show nothing rather than
 		-- matching every URL substring.
@@ -15,7 +17,7 @@ return {
 		end
 
 		-- Canonical listing path (same vote/comment aggregates as everywhere
-		-- else); the LIKE filter matches the host inside the stored URL.
+		-- else); the filter is an exact match on the stored posts.domain column.
 		self.posts = Posts:get_listing({ domain = self.domain })
 	end,
 

--- a/app/src/models/posts.lua
+++ b/app/src/models/posts.lua
@@ -67,6 +67,22 @@ Posts.statuses = enum({
 	deleted = 5,
 })
 
+--- Create a post, stamping the normalized link `domain` from its url.
+-- A single hook for every creation path (submit, crosspost, RSS import, seed)
+-- so the stored host stays consistent; self/relative posts (no host) store
+-- NULL. A url is set once at creation and never edited, so this is the only
+-- place the domain needs computing. Returns whatever Model:create returns
+-- (the row, or nil + error).
+-- @tparam table values column values, including the post `url`
+-- @return table|nil, string|nil
+function Posts:create(values, ...)
+	if type(values) == "table" and values.domain == nil then
+		local host = Url.domain(values.url)
+		values.domain = host ~= "" and host or nil
+	end
+	return Model.create(self, values, ...)
+end
+
 --- Get posts in a thread
 -- @tparam number post_id Post ID
 -- @tparam number offset Offset
@@ -94,7 +110,7 @@ function Posts:get_listing(filters)
 	filters = filters or {}
 
 	local query = [[
-		a.id, a.title, a.url, a.body, a.is_self, a.over_18, a.locked, a.sub_id, a.thumbnail,
+		a.id, a.title, a.url, a.body, a.is_self, a.over_18, a.locked, a.sub_id, a.thumbnail, a.domain,
 			a.stickied, a.comments_locked, a.is_question, a.accepted_comment_id,
 			a.created_at AS age, a.created_at,
 			c.user_name AS author,
@@ -129,7 +145,9 @@ function Posts:get_listing(filters)
 			.. ")"
 	end
 	if filters.domain then
-		query = query .. " AND a.url LIKE " .. db.escape_literal("%" .. filters.domain .. "%")
+		-- Exact match on the stored, normalized host (migration [108]) -- not a
+		-- substring of the raw url, which conflated notexample.com / ?ref=host.
+		query = query .. " AND a.domain = " .. db.escape_literal(filters.domain)
 	end
 	if filters.tag then
 		query = query
@@ -144,14 +162,85 @@ function Posts:get_listing(filters)
 
 	for _, post in ipairs(rows) do
 		post.permalink = "/r/" .. post.subreddit .. "/comments/" .. post.id
-		post.domain = Url.domain(post.url)
+		-- Prefer the stored host; fall back to parsing for any pre-backfill row.
+		post.domain = post.domain or Url.domain(post.url)
 	end
 
 	return rows
 end
 
+-- Shared projection for search results: the same vote/comment aggregates and
+-- enrichable columns get_listing returns, including the stored `domain`.
+local SEARCH_SELECT = [[
+	a.id, a.title, a.url, a.body, a.is_self, a.over_18, a.locked, a.sub_id, a.thumbnail, a.domain,
+		a.created_at AS age, a.created_at,
+		c.user_name AS author,
+		s.name AS subreddit,
+		(SELECT COUNT(*) FROM votes v WHERE v.post_id = a.id AND v.comment_id IS NULL AND v.upvote = 1) AS upvotes,
+		(SELECT COUNT(*) FROM votes v WHERE v.post_id = a.id AND v.comment_id IS NULL AND v.upvote = 0) AS downvotes,
+		(SELECT COUNT(*) FROM comments d WHERE d.post_id = a.id) AS num_comments ]]
+
+local function enrich(rows)
+	for _, post in ipairs(rows) do
+		post.permalink = "/r/" .. post.subreddit .. "/comments/" .. post.id
+		post.domain = post.domain or Url.domain(post.url)
+	end
+	return rows
+end
+
+-- A title word must score at least this Jaro-Winkler similarity against a query
+-- word to count as a fuzzy hit. High enough that only near-misses (typos) match,
+-- not loosely-related words.
+local FUZZY_WORD_THRESHOLD = 0.85
+
+--- Typo-tolerant fallback over post titles, used only when FTS5 found nothing
+-- and the sqlean `fuzzy`/`regexp` extensions are loaded. Compares words, not
+-- whole strings: each title is normalized (regexp_replace strips punctuation)
+-- and split into words by a recursive CTE, the query is split into words (a
+-- VALUES list), and a post matches when some title word is Jaro-Winkler-close to
+-- some query word -- so "programing" still finds "...programming...". This is
+-- what makes it work on multi-word titles. It scans every post, so it is gated
+-- behind an otherwise-empty FTS result (a rare path) and capped at 50 rows.
+-- @tparam string query
+-- @treturn table array of post rows (unenriched)
+local function fuzzy_title_search(query)
+	local terms = {}
+	for word in tostring(query):lower():gmatch("%w+") do
+		terms[#terms + 1] = "(" .. db.escape_literal(word) .. ")"
+	end
+	if #terms == 0 then
+		return {}
+	end
+
+	return db.select(SEARCH_SELECT .. [[
+		FROM posts a
+		INNER JOIN users c ON a.user_id = c.id
+		INNER JOIN forum s ON a.sub_id = s.id
+		INNER JOIN (
+			WITH RECURSIVE titlewords(id, word, rest) AS (
+				SELECT p.id, '', regexp_replace(lower(p.title), '[^a-z0-9]+', ' ') || ' '
+					FROM posts p WHERE p.deleted = 0 AND p.approved = 1
+				UNION ALL
+				SELECT id, substr(rest, 1, instr(rest, ' ') - 1), substr(rest, instr(rest, ' ') + 1)
+					FROM titlewords WHERE rest != ''
+			),
+			qwords(term) AS (VALUES ]] .. table.concat(terms, ", ") .. [[)
+			SELECT tw.id AS post_id, max(jaro_winkler(tw.word, q.term)) AS score
+				FROM titlewords tw, qwords q
+				WHERE tw.word != ''
+				GROUP BY tw.id
+				HAVING max(jaro_winkler(tw.word, q.term)) >= ]] .. FUZZY_WORD_THRESHOLD .. [[
+		) m ON m.post_id = a.id
+		ORDER BY m.score DESC, a.created_at DESC
+		LIMIT 50]])
+end
+
 --- Full-text search over post titles/bodies via the FTS5 index (migration [7]),
--- ordered by relevance. Returns the same enriched rows as get_listing.
+-- ordered by relevance. When FTS returns nothing and the sqlean extensions are
+-- loaded, retry with the word-level fuzzy pass above so a typo'd query
+-- ("programing") can still surface a near match. FTS stays the default and the
+-- fuzzy step only widens an otherwise-empty result, so behaviour is unchanged
+-- without the extensions. Returns the same enriched rows as get_listing.
 -- @tparam string query the user's search text
 -- @treturn table array of post rows
 function Posts:search(query)
@@ -162,31 +251,20 @@ function Posts:search(query)
 	-- MATCH syntax (double-quotes are escaped by doubling).
 	local phrase = '"' .. tostring(query):gsub('"', '""') .. '"'
 
-	local rows = db.select(
-		[[
-		a.id, a.title, a.url, a.body, a.is_self, a.over_18, a.locked, a.sub_id, a.thumbnail,
-			a.created_at AS age, a.created_at,
-			c.user_name AS author,
-			s.name AS subreddit,
-			(SELECT COUNT(*) FROM votes v WHERE v.post_id = a.id AND v.comment_id IS NULL AND v.upvote = 1) AS upvotes,
-			(SELECT COUNT(*) FROM votes v WHERE v.post_id = a.id AND v.comment_id IS NULL AND v.upvote = 0) AS downvotes,
-			(SELECT COUNT(*) FROM comments d WHERE d.post_id = a.id) AS num_comments
+	local rows = db.select(SEARCH_SELECT .. [[
 		FROM posts_fts f
 		INNER JOIN posts a ON a.id = f.rowid
 		INNER JOIN users c ON a.user_id = c.id
 		INNER JOIN forum s ON a.sub_id = s.id
 		WHERE posts_fts MATCH ? AND a.deleted = 0 AND a.approved = 1
 		ORDER BY rank
-		LIMIT 50]],
-		phrase
-	)
+		LIMIT 50]], phrase)
 
-	for _, post in ipairs(rows) do
-		post.permalink = "/r/" .. post.subreddit .. "/comments/" .. post.id
-		post.domain = Url.domain(post.url)
+	if #rows == 0 and require("src.utils.sqlite_ext").load() then
+		rows = fuzzy_title_search(query)
 	end
 
-	return rows
+	return enrich(rows)
 end
 
 --- Posts in a subreddit awaiting moderator approval (the queue), newest first.

--- a/docs/sqlean-plan.md
+++ b/docs/sqlean-plan.md
@@ -1,9 +1,17 @@
 # sqlean integration plan
 
-Plan for adding [sqlean](https://github.com/nalgeon/sqlean) loadable SQLite
-extensions. This is a **future infra task** — the payoff is modest and the cost
-(cross-platform binary bundling + a connection hook) is real, so it's deferred
-until a concrete need (typo-tolerant search is the most likely trigger).
+How we use [sqlean](https://github.com/nalgeon/sqlean) loadable SQLite
+extensions. **Status: implemented.** The bundle is pinned at `0.28.3` in the
+`Dockerfile` and loaded into Lapis's live connection per worker by
+`src/utils/sqlite_ext.lua`. Every feature that uses it has a Lua fallback, so the
+app still boots and the test suite still runs where the `.so` is absent.
+
+Note on function names: the docs at nalgeon/sqlean (even the `0.28.3` tag) only
+list the `fuzzy_*`-prefixed names (`fuzzy_jarowin`, `fuzzy_damlev`), but the
+actual bundled `sqlean.so` *also* registers unprefixed aliases — `jaro_winkler`,
+`dlevenshtein`, `levenshtein`, `soundex`, plus `regexp_like`/`regexp_substr`/
+`regexp_replace`. We use the unprefixed names (verified by introspecting
+`pragma_function_list` on the bundled `.so`).
 
 ## What we verified
 
@@ -16,69 +24,62 @@ until a concrete need (typo-tolerant search is the most likely trigger).
 - **`crypto` is unnecessary.** Secure tokens come from the built-in
   `hex(randomblob(32))` — no extension needed. This removes `crypto` from scope.
 
-## Module verdict (recap of TODO)
+## Module verdict (final)
 
 | Module | Verdict | Use |
 | --- | --- | --- |
-| `regexp` | useful | `regexp_substr(url, ...)` to extract `posts.domain` host in SQL |
-| `fuzzy` | useful | `dlevenshtein`/`soundex` typo-tolerant search ranking over FTS5 |
-| `crypto` | drop | built-in `randomblob`/`hex` already covers tokens |
-| `text`, `stats`, `math` | minor | doable in Lua / already in `sort.lua` |
-| `uuid`, `define` | maybe | external ids (future API), wrap `url_host` as a SQL func |
+| `fuzzy` | **adopted** | `jaro_winkler` for typo-tolerant subreddit search (`Forum:search`) and a word-level post-search fallback (`Posts:search`) |
+| `regexp` | **adopted (light)** | `regexp_replace` normalizes title punctuation when splitting words for the fuzzy post-search fallback |
+| `crypto` | dropped | tokens use `openssl.rand`; `randomblob`/`hex` cover the rest |
+| `text`, `stats`, `math` | not adopted | doable in Lua / already in `sort.lua` |
+| `uuid` | deferred | stable external ids, for the future API phase |
+| `define` | not adopted | no reusable SQL func needed (the `url_host` column was dropped) |
 | `ipaddr`, `vsv`, `unicode`, `time`, `besttype` | skip | not this workload |
 
 ## Implementation steps
 
-### 1. Bundle the binaries (Dockerfile)
-- Pin a sqlean release; download the Linux x86-64 build (production target is
-  amd64) into `/usr/local/lib/sqlean/`, verifying a checksum.
-- Only fetch the modules we use (`regexp.so`, `fuzzy.so`) to keep the image
-  small.
-- Dev note: on arm64 macOS, grab the matching macOS build or rely on Docker.
+### 1. Bundle the binary (Dockerfile) — done
+The `Dockerfile` downloads the pinned `0.28.3` Linux x86-64 single-file bundle
+(`sqlean.so`, all modules) to `/usr/local/lib/sqlite/`. One bundle is simpler
+than cherry-picking per-module `.so`s and the size cost is negligible. The build
+target is amd64; on arm64 macOS run the suite under Docker (see below).
 
-### 2. Load on every connection (`init_by_lua`, once per worker)
-Wrap `lsqlite3.open` so every connection Lapis opens auto-loads the modules.
-This is connection-correct and needs no patch to Lapis itself:
+### 2. Load onto Lapis's connection (per worker) — done
+`src/utils/sqlite_ext.lua` loads the bundle onto the *same* lsqlite3 connection
+Lapis runs queries on. Lapis keeps that connection as a private module upvalue
+(`active_connection`) with no accessor, so the loader reaches it via
+`debug.getupvalue` off one of the backend's closures, then calls
+`conn:load_extension(path)`. It is invoked from `app.lua`'s `before_filter`, so
+each nginx worker loads on its first request. `SQLITE_EXTENSIONS` overrides the
+path list (empty = disabled). The loader never raises; every consumer below is
+guarded by `sqlite_ext.load()` returning false and falls back to plain SQL/Lua.
 
-```lua
--- in config/init, before any DB use
-local lsqlite3 = require("lsqlite3")
-local real_open = lsqlite3.open
-local SQLEAN = "/usr/local/lib/sqlean/"
-lsqlite3.open = function(...)
-    local conn = real_open(...)
-    if conn then
-        for _, mod in ipairs({ "regexp", "fuzzy" }) do
-            -- default entrypoint sqlite3_<mod>_init matches the filename
-            pcall(function() conn:load_extension(SQLEAN .. mod) end)
-        end
-    end
-    return conn
-end
-```
+### 3. The consumers (each behind a capability check) — done
+- **`posts.domain`** — *not* a generated column. We store a normalized host in a
+  real column (migration `[108]`) computed in Lua by `Posts:create` (socket.url),
+  and backfilled. The generated-column form was declined: socket.url parses hosts
+  more correctly than `regexp_substr`, and a generated column calling an extension
+  function faults every INSERT (STORED) or SELECT (VIRTUAL) on a connection
+  without the `.so` — i.e. the test suite and `lapis migrate`.
+- **Subreddit search** (`Forum:search`) — `jaro_winkler` ranks typo-tolerant
+  name matches; falls back to a plain `LIKE` substring match.
+- **Post search** (`Posts:search` → `fuzzy_title_search`) — when FTS5 returns
+  nothing, a word-level fuzzy pass: each title is normalized with
+  `regexp_replace` and split into words (a recursive CTE), the query is split
+  into words, and a post matches when some title word is `jaro_winkler`-close
+  (≥ 0.85) to some query word. Word-level (not whole-string) matching is what
+  makes it work on multi-word titles. Gated behind an empty FTS result, capped
+  at 50 rows.
 
-Guard with a capability flag (`pcall` already degrades gracefully if a `.so` is
-absent) so the app still boots without the binaries — every feature below must
-have a Lua fallback.
+### 4. Tests + CI — done
+- `sqlite_ext_spec`, `forum_search_spec`, and `posts_search_spec` assert the
+  loaded behaviour; the extension-dependent examples mark themselves **pending**
+  when the `.so` is absent so the generic-Lua `test` job still runs green.
+- The `docker` CI job builds the production image (which carries the bundle) and
+  runs the full suite, so the loaded path is exercised end to end.
 
-### 3. Use the modules (incremental, each behind a capability check)
-- **`posts.domain`** — optionally a generated column
-  `GENERATED ALWAYS AS (regexp_substr(url, '://([^/]+)')) VIRTUAL`. Caveat:
-  generated columns referencing an extension function require the extension
-  loaded at both definition and query time; safer to keep the current Lua
-  computation in `get_listing` and only add this if profiling shows it matters.
-- **Search** — when an FTS5 query returns few hits, widen with a `dlevenshtein`
-  pass on titles. Keep the FTS5 path as the default and fallback.
+## Outcome
 
-### 4. Tests + CI
-- A spec asserting `load_extension` succeeds and `regexp_substr` /
-  `dlevenshtein` return expected values, **skipped** when the `.so` is absent so
-  the suite still runs on machines without the binaries.
-- CI already builds the Docker image (which would carry the `.so`s), so the
-  integration smoke covers the loaded path.
-
-## Recommendation
-
-Defer until typo-tolerant search is actually prioritized. At that point do steps
-1–2 + the `fuzzy` search fallback only; treat the `regexp` domain column as a
-separate, optional follow-up. `crypto` is off the table (built-ins suffice).
+`fuzzy` (+ a touch of `regexp`) is the payoff; `crypto` stays off the table
+(built-ins suffice); `uuid` waits for the API phase. Everything else in the
+bundle is loaded but unused — harmless, and there if a future need appears.


### PR DESCRIPTION
## Summary
Finishes the two open SQLite-performance items in `TODO.md`.

### Part A — `posts.domain`
- New **stored, indexed `domain` column** (migration `[108]`): the normalized link host, computed once at write time by `Posts:create` (via `utils/url`'s `socket.url` parser) and backfilled for existing rows.
- **Fixes the `/domain/:host` filter**, which was a substring `url LIKE '%host%'` that wrongly matched `notexample.com` / `?ref=host` — now an **exact, indexed match**. `domain.lua` normalizes the incoming param.
- The `GENERATED ALWAYS AS (...)` form was **evaluated and declined**: `socket.url` parses hosts more correctly than any SQL regex, and an extension-backed generated column faults every `INSERT` (STORED) or `SELECT` (VIRTUAL) on a connection without the sqlean `.so` (the test suite, `lapis migrate`).

### Part B — sqlean
- **`fuzzy` adopted/expanded:** word-level typo-tolerant **post-search fallback** (`Posts:search` → `fuzzy_title_search`). When FTS5 returns nothing, titles are normalized with `regexp_replace`, split into words via a recursive CTE, and matched per-word with `jaro_winkler ≥ 0.85`. FTS5 stays the default; the fallback only widens an empty result.
- **`regexp` adopted lightly** (title normalization). `crypto` dropped, `text`/`stats`/`math` left in Lua, `uuid` deferred to the API phase. Final per-module write-up in `docs/sqlean-plan.md`.
- Verified against the bundled `0.28.3` `.so` that it registers the unprefixed aliases (`jaro_winkler`, `dlevenshtein`, `regexp_replace`) the code uses.

All consumers are behind capability checks with plain-SQL/Lua fallbacks, so nothing regresses when the `.so` is absent.

## Test plan
Ran the full suite **in the production Docker image with the sqlean bundle loaded** (the `docker` CI path):
- **246 specs: 0 failures / 0 errors / 0 pending** (fuzzy + extension specs actually run, not skipped)
- **luacheck: 0 warnings / 0 errors** · **stylua --check: clean**

New specs cover create-time stamping, the substring→exact filter fix, the `[108]` backfill branch, and the fuzzy post-search fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)