### PR TITLE
feat(api): implement Reddit-flavoured JSON API (sqlite/sqlean/lapis)

### DIFF
--- a/.luacov
+++ b/.luacov
@@ -14,9 +14,6 @@ return {
 	exclude = {
 		"^app/spec/",
 		"^app/static/",
-		-- api.lua is ~150 disabled stub endpoints (deferred to a future phase,
-		-- not wired into app.lua), so it isn't meaningful coverage.
-		"^app/src/api$",
 		"luacov",
 		"busted",
 		"lapis",

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ matrix (`owner`/`moderator`/`member` + site `admin`); an Admin Control Panel
 (`/admin`); cached user reputation + trust levels; a new-user post-approval
 queue (`/r/:sub/queue`) with rate limiting; tags (`/t/:tag`); `@mentions`;
 accept-answer Q&A mode; and OAuth login. The Docker image boots and serves;
-**219-spec Busted suite + luacheck pass**.
+**274-spec Busted suite + luacheck pass**.
 
 ## Next up
 - [x] **Auth/password hardening** (issue #6): bcrypt password hashing
@@ -137,9 +137,30 @@ dependency-driven (foundations first); full plan in
       /post/:id/crosspost` re-shares into another sub via
       `posts.crosspost_parent_id` with source attribution. (Video embeds still
       out of scope.)
-- **API — deferred to a future phase.** `src/api.lua` is ~150 stub endpoints,
-  disabled in `app.lua`. Intentionally on hold until the web browsing
-  experience is locked in.
+- [x] **JSON API (first slice)** — `src/api.lua` is now a real, enabled
+      Reddit-flavoured JSON API (no longer the ~150-endpoint stub). Everything is
+      namespaced under `/api/` so it never collides with the HTML app's
+      `/(:sort)` / `/r/...` routes, and every response is a Reddit "Thing"
+      (`t1`/`t2`/`t3`/`t5`) or `Listing` envelope built by `utils/api_serialize`
+      (base36 ids + `t?_<id>` fullnames, plus an opaque stable `uuid`). All reads
+      and writes go through the existing models — nothing is re-queried by hand.
+      - *Reads:* `/api/v1/me`, `/api/v1/me/karma`, `/api/me/saved`,
+        `/api/listing(/:sort)`, `/api/r/:sub(/:sort)`, `/api/r/:sub/about`,
+        `/api/comments/:id` (link + nested comment tree), `/api/info?id=`,
+        `/api/search`, `/api/subreddits(/:where)`, `/api/subreddits/search`,
+        `/api/user/:name/about`, `/api/username_available`. Sorts reuse
+        `utils/sort`; `?t=` reuses `utils/timewindow`; FTS5 + fuzzy reuse
+        `Posts:search`; cursor pagination via `?after`/`?before`/`?limit`.
+      - *Writes (session + the global CSRF filter, accepts `X-Csrf-Token`):*
+        `/api/vote` (new explicit `Votes:set`), `/api/save`/`unsave`,
+        `/api/hide`/`unhide`, `/api/subscribe`, `/api/submit`, `/api/comment`,
+        `/api/del`, `/api/editusertext` — each enforcing the same spam / rate
+        limit / approval-queue / ownership rules as the web actions.
+      - Covered by `api_spec.lua` (16 cases) on top of the existing suite.
+      - *Backlog (not in this slice):* OAuth **bearer-token** auth (writes
+        currently reuse the browser's session + CSRF), and the Reddit surfaces
+        with no backing data (multis, wiki, modmail, gold/awards, friends,
+        trophies, prefs, captcha).
 - [x] **robots.txt / sitemap / well-known** — app-served `/robots.txt`,
       `/sitemap.xml` (subreddits + recent posts), and `/.well-known/security.txt`
       (RFC 9116). Output RSS feeds already done above.
@@ -197,7 +218,10 @@ dependency-driven (foundations first); full plan in
   - `text` — **not adopted**: `text_substring`/`split` are doable in Lua.
   - `stats` / `math` — **not adopted**: `hot`/`rising` math stays in `sort.lua`;
     revisit if SQL-side ranking becomes a bottleneck.
-  - `uuid` — **deferred to the API phase**: stable external ids.
+  - `uuid` — **adopted (API phase)**: each public row carries an opaque, stable
+    `public_id` UUID (migration `[109]`, exposed as a Thing's `uuid`), minted by
+    `utils/uuid` which prefers sqlean's `uuid4()` and falls back to
+    `openssl.rand` so the test suite / `lapis migrate` (no `.so`) still work.
   - `define` — **not adopted**: no reusable SQL function needed once the
     `url_host` generated column was dropped.
   - `ipaddr`, `vsv`, `unicode`, `time`, `besttype` — **not needed** for this
@@ -256,7 +280,7 @@ dependency-driven (foundations first); full plan in
     `-- TODO rename` marker.
 
 ## Test & quality
-- **219 specs** (model/SQL + full HTTP integration via `simulate_request`), luacov
+- **274 specs** (model/SQL + full HTTP integration via `simulate_request`), luacov
   coverage, and **luacheck** (0 warnings / 0 errors).
 - CI per push: super-linter, **stylua** (`--check app`), **luacheck**
   (`luacheck app`), **busted + luacov** (with an 80% coverage gate), and a

--- a/app/app.lua
+++ b/app/app.lua
@@ -159,7 +159,7 @@ app:match("/test/:comment_id[%d]", r2(require("actions.comment")))
 
 app:match("/console", console.make()) -- only available in Development builds
 
--- require("src.api")(app) -- API endpoints
+require("src.api")(app) -- JSON API endpoints (Reddit-flavoured, under /api)
 require("src.auth")(app) -- User-authenticated endpoints
 require("src.admin")(app) -- Admin Control Panel (site-admin only)
 

--- a/app/migrations.lua
+++ b/app/migrations.lua
@@ -864,6 +864,33 @@ return {
 		end
 	end,
 
+	-- Stable external ids for the API (docs/sqlean-plan.md earmarked `uuid` for
+	-- this phase). Each public-facing row gets an opaque `public_id` UUID so the
+	-- JSON API can reference it without leaking the guessable auto-increment id.
+	-- Nullable + backfilled here (rather than a NOT NULL default of uuid4()):
+	-- an extension-backed default would fault every INSERT on a connection
+	-- without the sqlean .so loaded -- i.e. the test suite and `lapis migrate`.
+	-- New rows are filled lazily on first serialization (utils.api_serialize);
+	-- this backfills everything that already exists.
+	[109] = function()
+		local uuid = require("src.utils.uuid")
+		for _, tbl in ipairs({ "posts", "comments", "users", "forum" }) do
+			local has_col = false
+			for _, c in ipairs(db.query("PRAGMA table_info(" .. tbl .. ")")) do
+				if c.name == "public_id" then
+					has_col = true
+				end
+			end
+			if not has_col then
+				schema.add_column(tbl, "public_id", types.text({ null = true }))
+			end
+			schema.create_index(tbl, "public_id", { unique = true, if_not_exists = true })
+			for _, row in ipairs(db.select("id FROM " .. tbl .. " WHERE public_id IS NULL")) do
+				db.update(tbl, { public_id = uuid.generate() }, { id = row.id })
+			end
+		end
+	end,
+
 	-- classify text : https://github.com/leafo/lapis-bayes
 	[1439944992] = require("lapis.bayes.schema").run_migrations,
 }

--- a/app/spec/api_spec.lua
+++ b/app/spec/api_spec.lua
@@ -1,0 +1,310 @@
+--- API spec: drives the JSON API through simulate_request (routing, auth/CSRF,
+--- serialization) and asserts the Reddit-flavoured Thing/Listing envelopes.
+
+local use_test_env = require("lapis.spec").use_test_env
+local simulate_request = require("lapis.spec.request").simulate_request
+local cjson = require("cjson")
+
+describe("api", function()
+	use_test_env()
+
+	local Users = require("models.users")
+	local Forum = require("src.models.forum")
+	local Posts = require("src.models.posts")
+	local Comments = require("models.comments")
+	local Votes = require("src.models.votes")
+	local S = require("src.utils.api_serialize")
+	local app = require("app")
+
+	-- Same CSRF trick as integration_spec: one (cookie, token) pair valid for
+	-- every POST (the global before_filter only checks the token against the
+	-- cookie, and accepts it from the csrf_token param).
+	local encoding = require("lapis.util.encoding")
+	local config = require("lapis.config").get()
+	local CSRF_COOKIE = config.session_name .. "_token"
+	local CSRF_KEY = "spec-csrf-key"
+	local CSRF_TOKEN = encoding.encode_with_secret({ k = CSRF_KEY })
+
+	local function GET(url, user)
+		return simulate_request(app, url, {
+			method = "GET",
+			session = user and { current_user = user } or nil,
+		})
+	end
+	local function POST(url, params, user)
+		params = params or {}
+		if params.csrf_token == nil then
+			params.csrf_token = CSRF_TOKEN
+		end
+		return simulate_request(app, url, {
+			method = "POST",
+			post = params,
+			session = user and { current_user = user } or nil,
+			cookies = { [CSRF_COOKIE] = CSRF_KEY },
+		})
+	end
+	local function body_of(url, user)
+		local status, body = GET(url, user)
+		return status, cjson.decode(body)
+	end
+	-- Decode a (status, body) POST result: `body_of_post(POST(...))`.
+	local function body_of_post(status, body)
+		return status, cjson.decode(body)
+	end
+
+	local sub, post, comment, demo
+
+	setup(function()
+		require("spec.schema_helper")()
+		demo =
+			Users:create({ user_name = "apidemo", user_pass = "password", user_email = "a@e.com" })
+		sub = Forum:create({ name = "apisub", creator_id = demo.id, description = "API sub" })
+		-- Make the author a moderator so submit/comment posts aren't held in the
+		-- new-user approval queue (mirrors integration_spec's flair_user).
+		Forum:add_moderator(sub.id, demo.id)
+		post = Posts:create({
+			user_id = demo.id,
+			sub_id = sub.id,
+			title = "API Hello",
+			url = "https://api.example.com/x",
+		})
+		comment =
+			Comments:create({ post_id = post.id, user_id = demo.id, body = "api comment one" })
+	end)
+
+	describe("listings", function()
+		it("serves the frontpage listing as Things", function()
+			local status, json = body_of("/api/listing")
+			assert.same(200, status)
+			assert.same("Listing", json.kind)
+			assert.truthy(#json.data.children > 0)
+			assert.same("t3", json.data.children[1].kind)
+			local found
+			for _, c in ipairs(json.data.children) do
+				if c.data.title == "API Hello" then
+					found = c
+				end
+			end
+			assert.truthy(found)
+			assert.same(S.fullname("link", post.id), found.data.name)
+			assert.same("api.example.com", found.data.domain)
+			assert.truthy(found.data.uuid)
+		end)
+
+		it("accepts a sort segment", function()
+			assert.same(200, (GET("/api/listing/top")))
+			assert.same(200, (GET("/api/listing/new")))
+		end)
+
+		it("serves a subreddit listing", function()
+			local status, json = body_of("/api/r/apisub")
+			assert.same(200, status)
+			assert.same("Listing", json.kind)
+		end)
+
+		it("404s an unknown subreddit listing", function()
+			assert.same(404, (GET("/api/r/nope")))
+		end)
+	end)
+
+	describe("about / lookup", function()
+		it("returns a subreddit Thing (literal about beats the sort route)", function()
+			local status, json = body_of("/api/r/apisub/about")
+			assert.same(200, status)
+			assert.same("t5", json.kind)
+			assert.same("apisub", json.data.display_name)
+			assert.same("r/apisub", json.data.display_name_prefixed)
+		end)
+
+		it("returns an account Thing", function()
+			local status, json = body_of("/api/user/apidemo/about")
+			assert.same(200, status)
+			assert.same("t2", json.kind)
+			assert.same("apidemo", json.data.name)
+		end)
+
+		it("resolves fullnames via /api/info", function()
+			local ids = S.fullname("link", post.id) .. "," .. S.fullname("comment", comment.id)
+			local status, json = body_of("/api/info?id=" .. ids)
+			assert.same(200, status)
+			assert.same(2, #json.data.children)
+			assert.same("t3", json.data.children[1].kind)
+			assert.same("t1", json.data.children[2].kind)
+		end)
+
+		it("reports username availability", function()
+			local _, taken = body_of("/api/username_available?user=apidemo")
+			assert.same(false, taken.available)
+			local _, free = body_of("/api/username_available?user=totallyfreename")
+			assert.same(true, free.available)
+			local _, reserved = body_of("/api/username_available?user=admin")
+			assert.same(false, reserved.available)
+		end)
+	end)
+
+	describe("comments tree", function()
+		it("returns [link, comments] with the comment nested", function()
+			local status, json = body_of("/api/comments/" .. post.id)
+			assert.same(200, status)
+			assert.same("Listing", json[1].kind)
+			assert.same("t3", json[1].data.children[1].kind)
+			assert.same("Listing", json[2].kind)
+			local bodies = {}
+			for _, c in ipairs(json[2].data.children) do
+				bodies[c.data.body] = true
+			end
+			assert.truthy(bodies["api comment one"])
+		end)
+	end)
+
+	describe("search", function()
+		it("finds posts via FTS", function()
+			local status, json = body_of("/api/search?q=Hello")
+			assert.same(200, status)
+			assert.same("Listing", json.kind)
+			assert.truthy(#json.data.children > 0)
+		end)
+
+		it("finds subreddits by name", function()
+			local status, json = body_of("/api/subreddits/search?q=apisub")
+			assert.same(200, status)
+			assert.same("t5", json.data.children[1].kind)
+		end)
+
+		it("lists the subreddit directory", function()
+			local status, json = body_of("/api/subreddits")
+			assert.same(200, status)
+			assert.same("Listing", json.kind)
+		end)
+	end)
+
+	describe("account (auth)", function()
+		it("401s /api/v1/me when logged out", function()
+			assert.same(401, (GET("/api/v1/me")))
+		end)
+
+		it("returns the current account", function()
+			local status, json = body_of("/api/v1/me", "apidemo")
+			assert.same(200, status)
+			assert.same("apidemo", json.name)
+			assert.truthy(json.uuid)
+		end)
+
+		it("returns a karma breakdown", function()
+			local status, json = body_of("/api/v1/me/karma", "apidemo")
+			assert.same(200, status)
+			assert.same("KarmaList", json.kind)
+			assert.truthy(json.data[1])
+		end)
+	end)
+
+	describe("vote (auth)", function()
+		it("401s without a session", function()
+			assert.same(401, (POST("/api/vote", { id = S.fullname("link", post.id), dir = 1 })))
+		end)
+
+		it("rejects a bad dir", function()
+			assert.same(
+				400,
+				(POST("/api/vote", { id = S.fullname("link", post.id), dir = 5 }, "apidemo"))
+			)
+		end)
+
+		it("casts and clears an explicit post vote", function()
+			local p = Posts:create({
+				user_id = demo.id,
+				sub_id = sub.id,
+				title = "votable",
+				url = "https://v.example",
+			})
+			local fn = S.fullname("link", p.id)
+			local _, up = body_of_post(POST("/api/vote", { id = fn, dir = 1 }, "apidemo"))
+			assert.same(1, Votes:post_score(p.id))
+			POST("/api/vote", { id = fn, dir = 0 }, "apidemo")
+			assert.same(0, Votes:post_score(p.id))
+			assert.truthy(up)
+		end)
+	end)
+
+	describe("save / hide (auth)", function()
+		it("saves then lists then unsaves", function()
+			local fn = S.fullname("link", post.id)
+			assert.same(200, (POST("/api/save", { id = fn }, "apidemo")))
+			local _, saved = body_of("/api/me/saved", "apidemo")
+			local titles = {}
+			for _, c in ipairs(saved.data.children) do
+				titles[c.data.title] = true
+			end
+			assert.truthy(titles["API Hello"])
+			assert.same(200, (POST("/api/unsave", { id = fn }, "apidemo")))
+		end)
+
+		it("hides a post from the owner's listing", function()
+			local p = Posts:create({
+				user_id = demo.id,
+				sub_id = sub.id,
+				title = "HIDE_ME_TITLE",
+				url = "https://h.example",
+			})
+			POST("/api/hide", { id = S.fullname("link", p.id) }, "apidemo")
+			local _, json = body_of("/api/listing", "apidemo")
+			for _, c in ipairs(json.data.children) do
+				assert.not_same("HIDE_ME_TITLE", c.data.title)
+			end
+		end)
+	end)
+
+	describe("subscribe (auth)", function()
+		it("subscribes and unsubscribes", function()
+			local fn = S.fullname("subreddit", sub.id)
+			POST("/api/subscribe", { sr = fn, action = "sub" }, "apidemo")
+			local Subscriptions = require("models.subscriptions")
+			assert.truthy(Subscriptions:is_subscribed(demo.id, sub.id))
+			POST("/api/subscribe", { sr_name = "apisub", action = "unsub" }, "apidemo")
+			assert.falsy(Subscriptions:is_subscribed(demo.id, sub.id))
+		end)
+	end)
+
+	describe("submit / comment / edit / del (auth)", function()
+		it("submits a self post", function()
+			local status, json = body_of_post(POST("/api/submit", {
+				sr = "apisub",
+				kind = "self",
+				title = "Submitted via API",
+				text = "hello body",
+			}, "apidemo"))
+			assert.same(201, status)
+			assert.same("t3", json.thing.kind)
+			assert.same("Submitted via API", json.thing.data.title)
+			assert.is_true(json.thing.data.is_self)
+		end)
+
+		it("comments on a post", function()
+			local status, json = body_of_post(POST("/api/comment", {
+				parent = S.fullname("link", post.id),
+				text = "a fresh api reply",
+			}, "apidemo"))
+			assert.same(201, status)
+			assert.same("t1", json.thing.kind)
+			assert.same("a fresh api reply", json.thing.data.body)
+		end)
+
+		it("edits and deletes own post", function()
+			local p = Posts:create({
+				user_id = demo.id,
+				sub_id = sub.id,
+				title = "editable",
+				body = "old",
+				is_self = 1,
+			})
+			local fn = S.fullname("link", p.id)
+			assert.same(
+				200,
+				(POST("/api/editusertext", { thing_id = fn, text = "new body" }, "apidemo"))
+			)
+			assert.same("new body", Posts:find(p.id).body)
+			assert.same(200, (POST("/api/del", { id = fn }, "apidemo")))
+			assert.same(1, tonumber(Posts:find(p.id).deleted))
+		end)
+	end)
+end)

--- a/app/spec/schema_helper.lua
+++ b/app/spec/schema_helper.lua
@@ -31,6 +31,7 @@ return function()
 		106,
 		107,
 		108,
+		109,
 	}) do
 		if migrations[k] then
 			migrations[k]()

--- a/app/src/api.lua
+++ b/app/src/api.lua
@@ -1,464 +1,583 @@
---- API URLs
+--- JSON API
 -- @module src.api
+--
+-- A Reddit-flavoured JSON API over the same models the web app uses. Every
+-- endpoint returns "Thing"/"Listing" envelopes (see utils.api_serialize) and
+-- reuses the existing models for all reads and writes -- nothing here re-queries
+-- by hand where a model method already does it.
+--
+-- Routing: everything is namespaced under `/api/` so it never collides with the
+-- HTML app's `/(:sort)` homepage catch-all or its `/r/...` routes. (The old stub
+-- mirrored Reddit's bare paths like `/hot` and `/r/:sub/about`, which would have
+-- shadowed -- or been shadowed by -- the live HTML routes.)
+--
+-- Auth + CSRF: write endpoints run behind the same session login and the global
+-- CSRF before_filter as the web forms (app.lua), which accepts the token from an
+-- `X-Csrf-Token` header as well as a `csrf_token` param. A future phase can add
+-- OAuth bearer tokens; for now an API client authenticates with the session
+-- cookie + CSRF token, exactly like the browser.
+
+local db = require("lapis.db")
+local S = require("src.utils.api_serialize")
+local Sort = require("src.utils.sort")
+local timewindow = require("src.utils.timewindow")
+
+local Users = require("models.users")
+local Posts = require("src.models.posts")
+local Comments = require("models.comments")
+local Forum = require("src.models.forum")
+local Votes = require("src.models.votes")
+local SavedPosts = require("models.saved_posts")
+local HiddenPosts = require("models.hidden_posts")
+local Subscriptions = require("models.subscriptions")
+
+-- Flood-control budgets, matching the web submit/comment actions.
+local POST_RATE, POST_WINDOW = 10, 600
+local COMMENT_RATE, COMMENT_WINDOW = 30, 600
+
+-- Sorts that map to a Sort comparator. "new" is intentionally absent: the
+-- listing query already returns rows newest-first, so we leave that order be.
+local SORTS = {
+	hot = true,
+	top = true,
+	best = true,
+	controversial = true,
+	rising = true,
+	new = true,
+}
+
+-- ---- response helpers --------------------------------------------------------
+
+local function err(status, message)
+	return { status = status, json = { error = status, message = message } }
+end
+
+-- The logged-in user row, or nil. Mirrors the action auth pattern.
+local function current_user(self)
+	return self.session.current_user and Users:find({ user_name = self.session.current_user })
+		or nil
+end
+
+-- ---- listing assembly --------------------------------------------------------
+
+-- Order a fresh listing by the requested sort (default "hot"); "new" keeps the
+-- query's created-desc order.
+local function sorted_listing(rows, sort)
+	if sort == "new" then
+		return rows
+	end
+	return Sort:sort(rows, sort)
+end
+
+-- Build a paginated link Listing from get_listing `filters`, reading
+-- sort/t/limit/after/before from the request.
+local function link_listing(self, filters)
+	local sort = self.params.sort
+	if not SORTS[sort] then
+		sort = "hot"
+	end
+	filters.since = timewindow(self.params.t)
+	local user = current_user(self)
+	if user then
+		filters.exclude_hidden_for = user.id
+	end
+
+	local rows = sorted_listing(Posts:get_listing(filters), sort)
+	local page, after, before = S.paginate(rows, self.params, "link")
+	local children = {}
+	for _, p in ipairs(page) do
+		children[#children + 1] = S.link(p)
+	end
+	return { json = S.listing(children, { after = after, before = before }) }
+end
+
+-- Nest a flat (path-ordered) thread into Reddit's recursive reply Listings.
+local function comment_tree(post_id)
+	local by_id, roots = {}, {}
+	for _, row in ipairs(Comments:thread(post_id)) do
+		local thing = S.comment(row)
+		by_id[row.id] = thing
+		local parent = row.parent_comment_id and by_id[row.parent_comment_id]
+		if parent then
+			if parent.data.replies == "" then
+				parent.data.replies = S.listing({})
+			end
+			local kids = parent.data.replies.data.children
+			kids[#kids + 1] = thing
+			parent.data.replies.data.dist = #kids
+		else
+			roots[#roots + 1] = thing
+		end
+	end
+	return S.listing(roots)
+end
+
+-- ---- the routes --------------------------------------------------------------
 
 local function api(app)
-	app:get("/api(*)", function(self)
-		return "NOTE: The API doesn't work but most endpoints exist"
+	-- Friendly index so a bare GET /api isn't a 404.
+	app:get("/api", function()
+		return {
+			json = {
+				name = "Page Six API",
+				note = "Reddit-flavoured JSON. Things are wrapped { kind, data }.",
+			},
+		}
 	end)
 
-	-- NOTE: the following endpoints aren't included:
-	--      collections, emoji, flair, gold, listings, live threads,
-	--      private messages, new modmail, modnote, multis, widgets, wiki
+	-- ---- account ----
 
-	-- account
+	-- The current account (Reddit returns the account `data` object directly).
 	app:get("/api/v1/me", function(self)
-		return "/api/v1/me"
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		return { json = S.account(user).data }
 	end)
-	app:get("/api/v1/me/blocked", function(self)
-		return "/api/v1/me/blocked"
-	end)
-	app:get("/api/v1/me/friends", function(self)
-		return "/api/v1/me/friends"
-	end)
+
+	-- Karma split into link (post) vs comment karma, Reddit's KarmaList shape.
 	app:get("/api/v1/me/karma", function(self)
-		return "/api/v1/me/karma"
-	end)
-	-- NOTE: requires respond_to() https://leafo.net/lapis/reference/actions.html#handling-http-verbs
-	-- app:patch("/api/v1/me/prefs",  function(self) return "/api/v1/me/prefs" end)
-	app:get("/api/v1/me/trophies", function(self)
-		return "/api/v1/me/trophies"
-	end)
-	app:get("/prefs/blocked", function(self)
-		return "/prefs/blocked"
-	end)
-	app:get("/prefs/friends", function(self)
-		return "/prefs/friends"
-	end)
-	app:get("/prefs/messaging", function(self)
-		return "/prefs/messaging"
-	end)
-	app:get("/prefs/trusted", function(self)
-		return "/prefs/trusted"
-	end)
-	app:get("/prefs/where", function(self)
-		return "/prefs/where"
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		local link = db.select(
+			[[COALESCE((SELECT SUM(CASE WHEN v.upvote = 1 THEN 1 ELSE -1 END)
+				FROM votes v JOIN posts p ON v.post_id = p.id
+				WHERE v.comment_id IS NULL AND p.user_id = ?), 0) AS k]],
+			user.id
+		)[1].k
+		local comment = db.select(
+			[[COALESCE((SELECT SUM(CASE WHEN v.upvote = 1 THEN 1 ELSE -1 END)
+				FROM votes v JOIN comments c ON v.comment_id = c.id
+				WHERE c.user_id = ?), 0) AS k]],
+			user.id
+		)[1].k
+		return {
+			json = {
+				kind = "KarmaList",
+				data = {
+					{
+						sr = "",
+						link_karma = tonumber(link) or 0,
+						comment_karma = tonumber(comment) or 0,
+					},
+				},
+			},
+		}
 	end)
 
-	-- captcha
-	app:get("/api/needs_captcha", function(self)
-		return "/api/needs_captcha"
+	-- The current user's saved posts.
+	app:get("/api/me/saved", function(self)
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		return link_listing(self, { saved_for = user.id })
 	end)
 
-	-- links & comments
-	app:post("/api/comment", function(self)
-		return "/api/comment"
+	-- ---- listings ----
+
+	-- Frontpage listing: GET /api/listing(/:sort)
+	app:get("/api/listing(/:sort)", function(self)
+		return link_listing(self, {})
 	end)
-	app:post("/api/del", function(self)
-		return "/api/del"
+
+	-- Subreddit "about": GET /api/r/:subreddit/about  (registered before the
+	-- sort catch-all so the literal `about` segment wins).
+	app:get("/api/r/:subreddit/about", function(self)
+		local sub = Forum:find({ name = self.params.subreddit })
+		if not sub then
+			return err(404, "Subreddit not found")
+		end
+		return { json = S.subreddit(sub) }
 	end)
-	app:post("/api/editusertext", function(self)
-		return "/api/editusertext"
+
+	-- Subreddit listing: GET /api/r/:subreddit(/:sort)
+	app:get("/api/r/:subreddit(/:sort)", function(self)
+		local sub = Forum:find({ name = self.params.subreddit })
+		if not sub then
+			return err(404, "Subreddit not found")
+		end
+		return link_listing(self, { sub_id = sub.id })
 	end)
-	app:post("/api/event_post_time", function(self)
-		return "/api/event_post_time"
+
+	-- A post and its comment tree: GET /api/comments/:post_id
+	-- Returns Reddit's two-element array: [ link Listing, comment Listing ].
+	app:get("/api/comments/:post_id[%d]", function(self)
+		local post = Posts:find(tonumber(self.params.post_id))
+		if not post or tonumber(post.deleted) == 1 then
+			return err(404, "Post not found")
+		end
+		return { json = { S.listing({ S.link(post) }), comment_tree(post.id) } }
 	end)
-	app:post("/api/follow_post", function(self)
-		return "/api/follow_post"
-	end)
-	app:post("/api/hide", function(self)
-		return "/api/hide"
-	end)
+
+	-- ---- lookup ----
+
+	-- GET /api/info?id=t3_x,t1_y,t5_z -- resolve fullnames to Things.
 	app:get("/api/info", function(self)
-		return "/api/info"
+		local children = {}
+		for name in tostring(self.params.id or ""):gmatch("[^,]+") do
+			local tbl, id = S.parse_fullname(name:match("^%s*(.-)%s*$"))
+			if tbl == "posts" then
+				local p = Posts:find(id)
+				if p and tonumber(p.deleted) ~= 1 then
+					children[#children + 1] = S.link(p)
+				end
+			elseif tbl == "comments" then
+				local c = Comments:find(id)
+				if c then
+					children[#children + 1] = S.comment(c)
+				end
+			elseif tbl == "forum" then
+				local f = Forum:find(id)
+				if f then
+					children[#children + 1] = S.subreddit(f)
+				end
+			elseif tbl == "users" then
+				local u = Users:find(id)
+				if u then
+					children[#children + 1] = S.account(u)
+				end
+			end
+		end
+		return { json = S.listing(children) }
 	end)
-	app:post("/api/lock", function(self)
-		return "/api/lock"
+
+	-- ---- search ----
+
+	-- Full-text post search: GET /api/search?q=
+	app:get("/api/search", function(self)
+		local rows = Posts:search(self.params.q)
+		local page, after, before = S.paginate(rows, self.params, "link")
+		local children = {}
+		for _, p in ipairs(page) do
+			children[#children + 1] = S.link(p)
+		end
+		return { json = S.listing(children, { after = after, before = before }) }
 	end)
-	app:post("/api/marknsfw", function(self)
-		return "/api/marknsfw"
+
+	-- ---- subreddits ----
+
+	-- Subreddit name search: GET /api/subreddits/search?q=
+	-- Forum:search projects list-card columns (no id); re-resolve each by name so
+	-- the API emits full Things (id/name/uuid) rather than degraded ones.
+	app:get("/api/subreddits/search", function(self)
+		local children = {}
+		for _, f in ipairs(Forum:search(self.params.q, tonumber(self.params.limit))) do
+			local full = Forum:find({ name = f.name })
+			if full then
+				children[#children + 1] = S.subreddit(full)
+			end
+		end
+		return { json = S.listing(children) }
 	end)
-	app:get("/api/morechildren", function(self)
-		return "/api/morechildren"
+
+	-- Subreddit directory: GET /api/subreddits(/:where) where=popular|new|default
+	app:get("/api/subreddits(/:where)", function(self)
+		local order = self.params.where == "new" and "s.created_at DESC"
+			or "subscribers DESC, s.name"
+		local rows = db.select([[
+			s.id, s.name, s.description, s.nsfw, s.created_at,
+				(SELECT COUNT(*) FROM subscriptions x WHERE x.subreddit_id = s.id) AS subscribers
+			FROM forum s WHERE s.deleted_at IS NULL
+			ORDER BY ]] .. order)
+		local page, after, before = S.paginate(rows, self.params, "subreddit")
+		local children = {}
+		for _, f in ipairs(page) do
+			children[#children + 1] = S.subreddit(f)
+		end
+		return { json = S.listing(children, { after = after, before = before }) }
 	end)
-	app:post("/api/report", function(self)
-		return "/api/report"
+
+	-- ---- users ----
+
+	-- GET /api/user/:username/about -- an account Thing.
+	app:get("/api/user/:username/about", function(self)
+		local user = Users:find({ user_name = self.params.username })
+		if not user then
+			return err(404, "User not found")
+		end
+		return { json = S.account(user) }
 	end)
-	app:post("/api/report_award", function(self)
-		return "/api/report_award"
+
+	-- GET /api/username_available?user=
+	app:get("/api/username_available", function(self)
+		local name = self.params.user
+		if not name or name == "" then
+			return err(400, "Missing user")
+		end
+		local reserved = db.select(
+			"1 FROM reserved_usernames WHERE user_name = ? LIMIT 1",
+			tostring(name):lower()
+		)[1]
+		local taken = Users:find({ user_name = name }) ~= nil
+		return { json = { available = (not reserved) and not taken } }
 	end)
+
+	-- ---- writes (auth + CSRF) ----
+
+	-- POST /api/vote  { id = t3_/t1_ fullname, dir = 1 | 0 | -1 }
+	app:post("/api/vote", function(self)
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		local dir = tonumber(self.params.dir)
+		if dir ~= 1 and dir ~= 0 and dir ~= -1 then
+			return err(400, "dir must be 1, 0, or -1")
+		end
+		local tbl, id = S.parse_fullname(self.params.id)
+		if tbl == "posts" then
+			local post = Posts:find(id)
+			if not post then
+				return err(404, "Post not found")
+			end
+			Votes:set(user.id, post.id, nil, dir)
+			Users:recompute_reputation(post.user_id)
+			return { json = { ok = true, id = self.params.id, score = Votes:post_score(post.id) } }
+		elseif tbl == "comments" then
+			local comment = Comments:find(id)
+			if not comment then
+				return err(404, "Comment not found")
+			end
+			Votes:set(user.id, comment.post_id, comment.id, dir)
+			Users:recompute_reputation(comment.user_id)
+			return {
+				json = { ok = true, id = self.params.id, score = Votes:comment_score(comment.id) },
+			}
+		end
+		return err(400, "Unknown thing id")
+	end)
+
+	-- Save/hide share a shape: a t3_ id and an idempotent set-to-state toggle.
+	local function set_post_flag(self, model, want)
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		local tbl, id = S.parse_fullname(self.params.id)
+		if tbl ~= "posts" then
+			return err(400, "Expected a link (t3_) id")
+		end
+		if not Posts:find(id) then
+			return err(404, "Post not found")
+		end
+		local is_set = model == SavedPosts and SavedPosts:is_saved(user.id, id)
+			or model == HiddenPosts and HiddenPosts:is_hidden(user.id, id)
+		if is_set ~= want then
+			model:toggle(user.id, id)
+		end
+		return { json = { ok = true } }
+	end
+
 	app:post("/api/save", function(self)
-		return "/api/save"
-	end)
-	app:get("/api/saved_categories", function(self)
-		return "/api/saved_categories"
-	end)
-	app:post("/api/sendreplies", function(self)
-		return "/api/sendreplies"
-	end)
-	app:post("/api/set_contest_mode", function(self)
-		return "/api/set_contest_mode"
-	end)
-	app:post("/api/set_subreddit_sticky", function(self)
-		return "/api/set_subreddit_sticky"
-	end)
-	app:post("/api/set_suggested_sort", function(self)
-		return "/api/set_suggested_sort"
-	end)
-	app:post("/api/spoiler", function(self)
-		return "/api/spoiler"
-	end)
-	app:post("/api/store_visits", function(self)
-		return "/api/store_visits"
-	end)
-	app:post("/api/submit", function(self)
-		return "/api/submit"
-	end)
-	app:post("/api/unhide", function(self)
-		return "/api/unhide"
-	end)
-	app:post("/api/unlock", function(self)
-		return "/api/unlock"
-	end)
-	app:post("/api/unmarknsfw", function(self)
-		return "/api/unmarknsfw"
+		return set_post_flag(self, SavedPosts, true)
 	end)
 	app:post("/api/unsave", function(self)
-		return "/api/unsave"
+		return set_post_flag(self, SavedPosts, false)
 	end)
-	app:post("/api/unspoiler", function(self)
-		return "/api/unspoiler"
+	app:post("/api/hide", function(self)
+		return set_post_flag(self, HiddenPosts, true)
 	end)
-	app:post("/api/vote", function(self)
-		return "/api/vote"
-	end)
-
-	-- listings
-	app:get("/best", function(self)
-		return "/best"
-	end)
-	app:get("/by_id/names", function(self)
-		return "/by_id/names"
-	end)
-	app:get("/comments/article", function(self)
-		return "/comments/article"
-	end)
-	app:get("/controversial", function(self)
-		return "/controversial"
-	end)
-	app:get("/duplicates/article", function(self)
-		return "/duplicates/article"
-	end)
-	app:get("/hot", function(self)
-		return "/hot"
-	end)
-	app:get("/new", function(self)
-		return "/new"
-	end)
-	app:get("/random", function(self)
-		return "/random"
-	end)
-	app:get("/rising", function(self)
-		return "/rising"
-	end)
-	app:get("/top", function(self)
-		return "/top"
-	end)
-	app:get("/sort", function(self)
-		return "/sort"
+	app:post("/api/unhide", function(self)
+		return set_post_flag(self, HiddenPosts, false)
 	end)
 
-	-- misc
-	app:get("/api/saved_media_text", function(self)
-		return "/api/saved_media_text"
-	end)
-	app:get("/api/v1/scopes", function(self)
-		return "/api/v1/scopes"
-	end)
-
-	-- moderation
-	app:get("/about/edited", function(self)
-		return "/about/edited"
-	end)
-	app:get("/about/log", function(self)
-		return "/about/log"
-	end)
-	app:get("/about/modqueue", function(self)
-		return "/about/modqueue"
-	end)
-	app:get("/about/reports", function(self)
-		return "/about/reports"
-	end)
-	app:get("/about/spam", function(self)
-		return "/about/spam"
-	end)
-	app:get("/about/unmoderated", function(self)
-		return "/about/unmoderated"
-	end)
-	app:get("/about/location", function(self)
-		return "/about/location"
-	end)
-	app:post("/api/accept_moderator_invite", function(self)
-		return "/api/accept_moderator_invite"
-	end)
-	app:post("/api/approve", function(self)
-		return "/api/approve"
-	end)
-	app:post("/api/distinguish", function(self)
-		return "/api/distinguish"
-	end)
-	app:post("/api/ignore_reports", function(self)
-		return "/api/ignore_reports"
-	end)
-	app:post("/api/leavecontributor", function(self)
-		return "/api/leavecontributor"
-	end)
-	app:post("/api/leavemoderator", function(self)
-		return "/api/leavemoderator"
-	end)
-	app:post("/api/mute_message_author", function(self)
-		return "/api/mute_message_author"
-	end)
-	app:post("/api/remove", function(self)
-		return "/api/remove"
-	end)
-	app:post("/api/show_comment", function(self)
-		return "/api/show_comment"
-	end)
-	app:post("/api/snooze_reports", function(self)
-		return "/api/snooze_reports"
-	end)
-	app:post("/api/unignore_reports", function(self)
-		return "/api/unignore_reports"
-	end)
-	app:post("/api/unmute_message_author", function(self)
-		return "/api/unmute_message_author"
-	end)
-	app:post("/api/unsnooze_reports", function(self)
-		return "/api/unsnooze_reports"
-	end)
-	app:post("/api/update_crowd_control_level", function(self)
-		return "/api/update_crowd_control_level"
-	end)
-	app:get("/stylesheet", function(self)
-		return "/stylesheet"
-	end)
-
-	-- multis
-	app:get("/api/filter/filterpath", function(self)
-		return "/api/filter/filterpath"
-	end)
-	app:get("/api/filter/filterpath/r/srname", function(self)
-		return "/api/filter/filterpath/r/srname"
-	end)
-	app:post("/api/multi/copy", function(self)
-		return "/api/multi/copy"
-	end)
-	app:get("/api/multi/mine", function(self)
-		return "/api/multi/mine"
-	end)
-	app:get("/api/multi/user/username", function(self)
-		return "/api/multi/user/username"
-	end)
-	app:delete("/api/multi/multipath", function(self)
-		return "/api/multi/multipath"
-	end)
-	app:get("/api/multi/multipath", function(self)
-		return "/api/multi/multipath"
-	end)
-	app:post("/api/multi/multipath", function(self)
-		return "/api/multi/multipath"
-	end)
-	app:put("/api/multi/multipath", function(self)
-		return "/api/multi/multipath"
-	end)
-	app:get("/api/multi/multipath/description", function(self)
-		return "/api/multi/multipath/description"
-	end)
-	app:put("/api/multi/multipath/description", function(self)
-		return "/api/multi/multipath/description"
-	end)
-	app:delete("/api/multi/multipath/r/srname", function(self)
-		return "/api/multi/multipath/r/srname"
-	end)
-	app:get("/api/multi/multipath/r/srname", function(self)
-		return "/api/multi/multipath/r/srname"
-	end)
-	app:put("/api/multi/multipath/r/srname", function(self)
-		return "/api/multi/multipath/r/srname"
-	end)
-
-	-- search
-	app:get("/search", function(self)
-		return "/search"
-	end)
-
-	-- subreddits
-	app:get("/about/banned", function(self)
-		return "/about/banned"
-	end)
-	app:get("/about/contributors", function(self)
-		return "/about/contributors"
-	end)
-	app:get("/about/moderators", function(self)
-		return "/about/moderators"
-	end)
-	app:get("/about/muted", function(self)
-		return "/about/muted"
-	end)
-	app:get("/about/wikibanned", function(self)
-		return "/about/wikibanned"
-	end)
-	app:get("/about/wikicontributors", function(self)
-		return "/about/wikicontributors"
-	end)
-	app:get("/about/where", function(self)
-		return "/about/where"
-	end)
-	app:post("/api/delete_sr_banner", function(self)
-		return "/api/delete_sr_banner"
-	end)
-	app:post("/api/delete_sr_header", function(self)
-		return "/api/delete_sr_header"
-	end)
-	app:post("/api/delete_sr_icon", function(self)
-		return "/api/delete_sr_icon"
-	end)
-	app:post("/api/delete_sr_img", function(self)
-		return "/api/delete_sr_img"
-	end)
-	app:get("/api/recommend/sr/srnames", function(self)
-		return "/api/recommend/sr/srnames"
-	end)
-	app:post("/api/search_reddit_names", function(self)
-		return "/api/search_reddit_names"
-	end)
-	app:post("/api/search_subreddits", function(self)
-		return "/api/search_subreddits"
-	end)
-	app:post("/api/site_admin", function(self)
-		return "/api/site_admin"
-	end)
-	app:get("/api/submit_text", function(self)
-		return "/api/submit_text"
-	end)
-	app:get("/api/subreddit_autocomplete", function(self)
-		return "/api/subreddit_autocomplete"
-	end)
-	app:get("/api/subreddit_autocomplete_v2", function(self)
-		return "/api/subreddit_autocomplete_v2"
-	end)
-	app:post("/api/subreddit_stylesheet", function(self)
-		return "/api/subreddit_stylesheet"
-	end)
+	-- POST /api/subscribe { sr = t5_ fullname OR sr_name = name, action = sub|unsub }
 	app:post("/api/subscribe", function(self)
-		return "/api/subscribe"
-	end)
-	app:post("/api/upload_sr_img", function(self)
-		return "/api/upload_sr_img"
-	end)
-	app:get("/api/v1/subreddit/post_requirements", function(self)
-		return "/api/v1/subreddit/post_requirements"
-	end)
-	app:get("/r/subreddit/about", function(self)
-		return "/r/subreddit/about"
-	end)
-	app:get("/r/subreddit/about/edit", function(self)
-		return "/r/subreddit/about/edit"
-	end)
-	app:get("/r/subreddit/about/rules", function(self)
-		return "/r/subreddit/about/rules"
-	end)
-	app:get("/r/subreddit/about/traffic", function(self)
-		return "/r/subreddit/about/traffic"
-	end)
-	app:get("/sidebar", function(self)
-		return "/sidebar"
-	end)
-	app:get("/sticky", function(self)
-		return "/sticky"
-	end)
-	app:get("/subreddits/default", function(self)
-		return "/subreddits/default"
-	end)
-	app:get("/subreddits/gold", function(self)
-		return "/subreddits/gold"
-	end)
-	app:get("/subreddits/mine/contributor", function(self)
-		return "/subreddits/mine/contributor"
-	end)
-	app:get("/subreddits/mine/moderator", function(self)
-		return "/subreddits/mine/moderator"
-	end)
-	app:get("/subreddits/mine/streams", function(self)
-		return "/subreddits/mine/streams"
-	end)
-	app:get("/subreddits/mine/subscriber", function(self)
-		return "/subreddits/mine/subscriber"
-	end)
-	app:get("/subreddits/mine/where", function(self)
-		return "/subreddits/mine/where"
-	end)
-	app:get("/subreddits/new", function(self)
-		return "/subreddits/new"
-	end)
-	app:get("/subreddits/popular", function(self)
-		return "/subreddits/popular"
-	end)
-	app:get("/subreddits/search", function(self)
-		return "/subreddits/search"
-	end)
-	app:get("/subreddits/where", function(self)
-		return "/subreddits/where"
-	end)
-	app:get("/users/new", function(self)
-		return "/users/new"
-	end)
-	app:get("/users/popular", function(self)
-		return "/users/popular"
-	end)
-	app:get("/users/search", function(self)
-		return "/users/search"
-	end)
-	app:get("/users/where", function(self)
-		return "/users/where"
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		local sub
+		if self.params.sr then
+			local tbl, id = S.parse_fullname(self.params.sr)
+			sub = tbl == "forum" and Forum:find(id) or nil
+		elseif self.params.sr_name then
+			sub = Forum:find({ name = self.params.sr_name })
+		end
+		if not sub then
+			return err(404, "Subreddit not found")
+		end
+		local want = self.params.action ~= "unsub"
+		if Subscriptions:is_subscribed(user.id, sub.id) ~= want then
+			Subscriptions:toggle(user.id, sub.id)
+		end
+		return { json = { ok = true, subscribed = want } }
 	end)
 
-	-- users
-	app:post("/api/block_user", function(self)
-		return "/api/block_user"
+	-- POST /api/submit { sr = name, kind = link|self, title, url, text }
+	app:post("/api/submit", function(self)
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		local sub = Forum:find({ name = self.params.sr or self.params.subreddit })
+		if not sub then
+			return err(404, "Subreddit not found")
+		end
+
+		local url = self.params.url
+		local text = self.params.text or self.params.body
+		local is_self = self.params.kind == "self" or ((url == nil or url == "") and text)
+		if is_self then
+			url = nil
+		elseif url == nil or url == "" then
+			return err(400, "Provide a url (link post) or text (self post)")
+		end
+
+		local Spam = require("src.utils.spam")
+		if Spam.is_spam((self.params.title or "") .. " " .. (text or "")) then
+			return err(422, "Your post looks like spam.")
+		end
+		if require("src.utils.ratelimit").exceeded("posts", user.id, POST_RATE, POST_WINDOW) then
+			return err(429, "You're posting too fast. Try again later.")
+		end
+
+		local held = require("src.utils.queue").should_hold(user, sub)
+		local post, create_err = Posts:create({
+			user_id = user.id,
+			sub_id = sub.id,
+			title = self.params.title,
+			url = url,
+			body = (text ~= "") and text or nil,
+			is_self = is_self and 1 or 0,
+			thumbnail = require("src.utils.media").thumbnail_for(url),
+			approved = held and 0 or 1,
+		})
+		if not post then
+			return err(422, create_err)
+		end
+		require("src.models.tags"):set_for_post(post.id, self.params.tags)
+
+		post.author, post.subreddit = user.user_name, sub.name
+		post.upvotes, post.downvotes, post.num_comments = 0, 0, 0
+		return { status = 201, json = { ok = true, pending = held, thing = S.link(post) } }
 	end)
-	app:post("(/r/:subreddit)/api/friend", function(self)
-		return "/api/friend"
+
+	-- POST /api/comment { parent = t3_/t1_ fullname, text }
+	app:post("/api/comment", function(self)
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		local tbl, id = S.parse_fullname(self.params.parent)
+		local post, parent
+		if tbl == "posts" then
+			post = Posts:find(id)
+		elseif tbl == "comments" then
+			parent = Comments:find(id)
+			post = parent and Posts:find(parent.post_id)
+		end
+		if not post then
+			return err(404, "Parent not found")
+		end
+		if tonumber(post.comments_locked) == 1 then
+			return err(403, "This thread is locked")
+		end
+
+		local Spam = require("src.utils.spam")
+		if Spam.is_spam(self.params.text) then
+			return err(422, "Your comment looks like spam.")
+		end
+		if
+			require("src.utils.ratelimit").exceeded(
+				"comments",
+				user.id,
+				COMMENT_RATE,
+				COMMENT_WINDOW
+			)
+		then
+			return err(429, "You're commenting too fast. Try again later.")
+		end
+
+		local sub = Forum:find(post.sub_id)
+		local held = require("src.utils.queue").should_hold(user, sub)
+		local comment, create_err = Comments:create({
+			post_id = post.id,
+			user_id = user.id,
+			parent_comment_id = parent and parent.id or nil,
+			body = self.params.text,
+			is_submitter = post.user_id == user.id and 1 or 0,
+			approved = held and 0 or 1,
+		})
+		if not comment then
+			return err(422, create_err)
+		end
+		if not held then
+			local recipient = parent and parent.user_id or post.user_id
+			if tonumber(recipient) ~= tonumber(user.id) then
+				require("models.notifications"):notify(
+					recipient,
+					comment.id,
+					parent and "comment_reply" or "post_reply"
+				)
+			end
+		end
+
+		-- Shape a thread-style row so the serializer has author/subreddit/score.
+		comment.author, comment.subreddit = user.user_name, sub.name
+		comment.upvotes, comment.downvotes = 0, 0
+		return { status = 201, json = { ok = true, pending = held, thing = S.comment(comment) } }
 	end)
-	app:post("/api/report_user", function(self)
-		return "/api/report_user"
+
+	-- POST /api/del { id = t3_/t1_ } -- soft-delete your own post or comment.
+	app:post("/api/del", function(self)
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		local tbl, id = S.parse_fullname(self.params.id)
+		if tbl == "posts" then
+			local post = Posts:find(id)
+			if post and post.user_id == user.id then
+				post:update({ deleted = 1 })
+			end
+		elseif tbl == "comments" then
+			local comment = Comments:find(id)
+			if comment and comment.user_id == user.id then
+				comment:update({ deleted = 1 })
+			end
+		else
+			return err(400, "Unknown thing id")
+		end
+		return { json = { ok = true } }
 	end)
-	app:post("/api/setpermissions", function(self)
-		return "/api/setpermissions"
-	end)
-	app:post("(/r/:subreddit)/api/unfriend", function(self)
-		return "/api/unfriend"
-	end)
-	app:get("/api/user_data_by_account_ids", function(self)
-		return "/api/user_data_by_account_ids"
-	end)
-	app:get("/api/username_available", function(self)
-		return "/api/username_available"
-	end)
-	app:delete("/api/v1/me/friends/username", function(self)
-		return "/api/v1/me/friends/username"
-	end)
-	app:get("/api/v1/me/friends/username", function(self)
-		return "/api/v1/me/friends/username"
-	end)
-	app:put("/api/v1/me/friends/username", function(self)
-		return "/api/v1/me/friends/username"
-	end)
-	app:get("/api/v1/user/username/trophies", function(self)
-		return "/api/v1/user/username/trophies"
-	end)
-	app:get("/user/username/:where", function(self)
-		return "/user/username/about"
+
+	-- POST /api/editusertext { thing_id = t3_/t1_, text } -- edit your own text.
+	app:post("/api/editusertext", function(self)
+		local user = current_user(self)
+		if not user then
+			return err(401, "Unauthorized")
+		end
+		local tbl, id = S.parse_fullname(self.params.thing_id)
+		if tbl == "posts" then
+			local post = Posts:find(id)
+			if not post or post.user_id ~= user.id then
+				return err(403, "Not your post")
+			end
+			if tonumber(post.is_self) ~= 1 or tonumber(post.deleted) == 1 then
+				return err(422, "Only your own non-deleted self-posts are editable")
+			end
+			post:update({ body = self.params.text, edited = 1 })
+			return { json = { ok = true, thing = S.link(post) } }
+		elseif tbl == "comments" then
+			local comment = Comments:find(id)
+			if not comment or comment.user_id ~= user.id then
+				return err(403, "Not your comment")
+			end
+			if tonumber(comment.deleted) == 1 then
+				return err(422, "Deleted comments can't be edited")
+			end
+			local ok, update_err = comment:update({ body = self.params.text, edited = 1 })
+			if not ok then
+				return err(422, update_err)
+			end
+			return { json = { ok = true } }
+		end
+		return err(400, "Unknown thing id")
 	end)
 
 	return app

--- a/app/src/models/votes.lua
+++ b/app/src/models/votes.lua
@@ -47,6 +47,45 @@ function Votes:cast(user_id, post_id, comment_id, upvote)
 	})
 end
 
+--- Set a user's vote on a post (or comment) to an explicit direction.
+-- Unlike cast() (which toggles for the web UI), this sets the exact state the
+-- API's `dir` field asks for: 1 = upvote, -1 = downvote, 0 = no vote (remove).
+-- Idempotent -- re-sending the same dir is a no-op.
+-- @tparam number user_id
+-- @tparam number post_id
+-- @tparam number|nil comment_id nil for a post vote
+-- @tparam number dir 1 (up), -1 (down), or 0 (remove)
+-- @treturn table|nil the vote row, or nil when removed / unchanged-to-absent
+function Votes:set(user_id, post_id, comment_id, dir)
+	local existing = self:find({
+		user_id = user_id,
+		post_id = post_id,
+		comment_id = comment_id or db.NULL,
+	})
+
+	if dir == 0 then
+		if existing then
+			existing:delete()
+		end
+		return nil
+	end
+
+	local upvote = dir == 1 and 1 or 0
+	if existing then
+		if tonumber(existing.upvote) ~= upvote then
+			existing:update({ upvote = upvote })
+		end
+		return existing
+	end
+
+	return self:create({
+		user_id = user_id,
+		post_id = post_id,
+		comment_id = comment_id,
+		upvote = upvote,
+	})
+end
+
 --- Net score (upvotes - downvotes) for a post's own votes (comment_id IS NULL).
 -- @tparam number post_id
 -- @treturn number

--- a/app/src/utils/api_serialize.lua
+++ b/app/src/utils/api_serialize.lua
@@ -1,0 +1,374 @@
+--- Reddit-shaped JSON serialization for the API
+-- @module utils.api_serialize
+--
+-- Turns our model rows into the "Thing" envelopes the Reddit API speaks:
+-- `{ kind = "t3", data = { ... } }` for a link, `t1` for a comment, `t2` for
+-- an account, `t5` for a subreddit, and `{ kind = "Listing", data = { children
+-- = { ... }, after, before, dist } }` for a page of them.
+--
+-- Two id schemes are exposed per thing:
+--   * `id` / `name` -- Reddit's base36 of the row id and its `t?_<id>` fullname,
+--     so existing Reddit API clients work unchanged.
+--   * `uuid` -- the opaque, stable `public_id` (migration [109]); minted lazily
+--     here the first time a row is serialized so old rows backfill on demand.
+
+local db = require("lapis.db")
+local uuid = require("src.utils.uuid")
+
+local M = {}
+
+-- Reddit "kind" prefixes. https://www.reddit.com/dev/api/#fullnames
+M.KINDS = {
+	comment = "t1",
+	account = "t2",
+	link = "t3",
+	message = "t4",
+	subreddit = "t5",
+}
+
+-- Map a prefix back to the table it identifies, for parse_fullname / /api/info.
+local PREFIX_TABLE = {
+	t1 = "comments",
+	t2 = "users",
+	t3 = "posts",
+	t5 = "forum",
+}
+
+local DIGITS = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+--- Encode a non-negative integer as lowercase base36 (Reddit's id alphabet).
+-- @tparam number n
+-- @treturn string
+function M.base36(n)
+	n = math.floor(tonumber(n) or 0)
+	if n == 0 then
+		return "0"
+	end
+	local out = {}
+	while n > 0 do
+		local r = n % 36
+		out[#out + 1] = DIGITS:sub(r + 1, r + 1)
+		n = math.floor(n / 36)
+	end
+	return string.reverse(table.concat(out))
+end
+
+--- Decode a base36 string back to a number, or nil if it isn't valid base36.
+-- @tparam string s
+-- @treturn number|nil
+function M.from_base36(s)
+	if type(s) ~= "string" or s == "" then
+		return nil
+	end
+	local n = 0
+	for i = 1, #s do
+		local d = DIGITS:find(s:sub(i, i):lower(), 1, true)
+		if not d then
+			return nil
+		end
+		n = n * 36 + (d - 1)
+	end
+	return n
+end
+
+--- Build a Reddit fullname, e.g. fullname("link", 42) -> "t3_16".
+-- @tparam string kind one of M.KINDS' keys
+-- @tparam number id
+-- @treturn string
+function M.fullname(kind, id)
+	return M.KINDS[kind] .. "_" .. M.base36(id)
+end
+
+--- Split a fullname into the table it points at and the numeric id.
+-- parse_fullname("t3_16") -> "posts", 42. Returns nil for anything malformed.
+-- @tparam string name
+-- @treturn string|nil table_name
+-- @treturn number|nil id
+function M.parse_fullname(name)
+	if type(name) ~= "string" then
+		return nil
+	end
+	local prefix, b36 = name:match("^(t%d)_(%w+)$")
+	local tbl = prefix and PREFIX_TABLE[prefix]
+	local id = tbl and M.from_base36(b36)
+	if not id then
+		return nil
+	end
+	return tbl, id
+end
+
+--- The stable `public_id` for a row, minting + persisting one if absent.
+-- Many listing projections don't SELECT `public_id`, so a nil on the row does
+-- not mean the column is unset -- we re-read it before minting, otherwise we'd
+-- clobber the backfilled (stable) value with a fresh one on every serialize.
+-- @tparam string table_name
+-- @tparam table row a row with `id` (and maybe `public_id`)
+-- @treturn string
+function M.ensure_public_id(table_name, row)
+	if row.public_id and row.public_id ~= "" then
+		return row.public_id
+	end
+	local stored = db.select("public_id FROM " .. table_name .. " WHERE id = ?", tonumber(row.id))
+	if stored[1] and stored[1].public_id and stored[1].public_id ~= db.NULL then
+		row.public_id = stored[1].public_id
+		return row.public_id
+	end
+	local id = uuid.generate()
+	db.update(table_name, { public_id = id }, { id = row.id })
+	row.public_id = id
+	return id
+end
+
+-- 0/1/"0"/"1"/nil -> boolean, for the integer flag columns.
+local function bool(v)
+	return tonumber(v) == 1
+end
+
+local function num(v)
+	return tonumber(v) or 0
+end
+
+-- Best-effort UTC epoch from a "YYYY-MM-DD HH:MM:SS" stored timestamp. The
+-- stored value is SQLite's CURRENT_TIMESTAMP (UTC); os.time treats the fields
+-- as local, so subtract the local<->UTC offset to land back on UTC. Returns 0
+-- when the timestamp is missing/unparseable.
+local function to_epoch(ts)
+	if type(ts) ~= "string" then
+		return 0
+	end
+	local y, mo, d, h, mi, s = ts:match("(%d+)-(%d+)-(%d+)%s+(%d+):(%d+):(%d+)")
+	if not y then
+		return 0
+	end
+	local offset = os.time() - os.time(os.date("!*t"))
+	return os.time({ year = y, month = mo, day = d, hour = h, min = mi, sec = s }) + offset
+end
+
+--- Serialize a post row as a `t3` link Thing. Accepts the enriched listing rows
+-- (author/subreddit/vote aggregates already joined) and falls back to lookups
+-- for a bare `Posts:find` row, so single-item endpoints work too.
+-- @tparam table p
+-- @treturn table
+function M.link(p)
+	local ups, downs
+	if p.upvotes ~= nil or p.downvotes ~= nil then
+		ups, downs = num(p.upvotes), num(p.downvotes)
+	else
+		-- Bare Posts:find row (single-item endpoints): count up/down directly so
+		-- the reported score matches the listing path's, not just the net.
+		local row = db.select(
+			[[SUM(CASE WHEN upvote = 1 THEN 1 ELSE 0 END) AS u,
+				SUM(CASE WHEN upvote = 0 THEN 1 ELSE 0 END) AS d
+				FROM votes WHERE post_id = ? AND comment_id IS NULL]],
+			tonumber(p.id)
+		)
+		ups, downs = num(row[1] and row[1].u), num(row[1] and row[1].d)
+	end
+
+	local subreddit = p.subreddit
+	if not subreddit and p.sub_id then
+		local sub = require("src.models.forum"):find(p.sub_id)
+		subreddit = sub and sub.name
+	end
+
+	local author = p.author
+	if not author and p.user_id then
+		local u = require("models.users"):find(p.user_id)
+		author = u and u.user_name
+	end
+
+	local num_comments = p.num_comments
+	if num_comments == nil then
+		local row = db.select("COUNT(*) AS c FROM comments WHERE post_id = ?", tonumber(p.id))
+		num_comments = row[1] and row[1].c or 0
+	end
+
+	return {
+		kind = M.KINDS.link,
+		data = {
+			id = M.base36(p.id),
+			name = M.fullname("link", p.id),
+			uuid = M.ensure_public_id("posts", p),
+			title = p.title,
+			url = p.url,
+			permalink = p.permalink or ("/r/" .. tostring(subreddit) .. "/comments/" .. p.id),
+			author = author,
+			subreddit = subreddit,
+			subreddit_name_prefixed = subreddit and ("r/" .. subreddit) or nil,
+			domain = p.domain,
+			selftext = p.body,
+			is_self = bool(p.is_self),
+			score = ups - downs,
+			ups = ups,
+			downs = downs,
+			num_comments = num(num_comments),
+			over_18 = bool(p.over_18),
+			stickied = bool(p.stickied),
+			locked = bool(p.locked),
+			link_flair_text = p.link_flair,
+			edited = bool(p.edited),
+			created = p.created_at,
+			created_utc = to_epoch(p.created_at),
+		},
+	}
+end
+
+--- Serialize a comment row (a `thread`/`by_user` row) as a `t1` Thing.
+-- @tparam table c
+-- @treturn table
+function M.comment(c)
+	local ups = num(c.upvotes)
+	local downs = num(c.downvotes)
+	return {
+		kind = M.KINDS.comment,
+		data = {
+			id = M.base36(c.id),
+			name = M.fullname("comment", c.id),
+			uuid = M.ensure_public_id("comments", c),
+			body = bool(c.deleted) and "[deleted]" or c.body,
+			author = bool(c.deleted) and "[deleted]" or c.author,
+			link_id = M.fullname("link", c.post_id),
+			parent_id = c.parent_comment_id and M.fullname("comment", c.parent_comment_id)
+				or M.fullname("link", c.post_id),
+			subreddit = c.subreddit,
+			score = ups - downs,
+			ups = ups,
+			downs = downs,
+			is_submitter = bool(c.is_submitter),
+			stickied = bool(c.stickied),
+			edited = bool(c.edited),
+			permalink = c.permalink,
+			created = c.created_at,
+			created_utc = to_epoch(c.created_at),
+			replies = "",
+		},
+	}
+end
+
+--- Serialize a user row as a `t2` account Thing. Following Reddit, `data.name`
+-- is the username (the thing's fullname is `t2_<id>`, exposed as `fullname`).
+-- @tparam table u
+-- @treturn table
+function M.account(u)
+	local Users = require("models.users")
+	return {
+		kind = M.KINDS.account,
+		data = {
+			id = M.base36(u.id),
+			name = u.user_name,
+			fullname = M.fullname("account", u.id),
+			uuid = M.ensure_public_id("users", u),
+			total_karma = Users:karma(u.id),
+			reputation = num(u.reputation),
+			trust_level = Users:trust_level(u.reputation),
+			over_18 = bool(u.over_18),
+			created = u.created_at,
+			created_utc = to_epoch(u.created_at),
+		},
+	}
+end
+
+--- Serialize a subreddit row as a `t5` Thing. Accepts a `forum` row or a
+-- listing row (which exposes `subscribers`).
+-- @tparam table f
+-- @treturn table
+function M.subreddit(f)
+	local subscribers = f.subscribers
+	if subscribers == nil and f.id then
+		local row =
+			db.select("COUNT(*) AS c FROM subscriptions WHERE subreddit_id = ?", tonumber(f.id))
+		subscribers = row[1] and row[1].c or 0
+	end
+	return {
+		kind = M.KINDS.subreddit,
+		data = {
+			id = f.id and M.base36(f.id) or nil,
+			name = f.id and M.fullname("subreddit", f.id) or nil,
+			uuid = f.id and M.ensure_public_id("forum", f) or nil,
+			display_name = f.name,
+			display_name_prefixed = "r/" .. f.name,
+			title = f.name,
+			public_description = f.description,
+			subscribers = num(subscribers),
+			over18 = bool(f.nsfw),
+			url = "/r/" .. f.name,
+			created = f.created_at,
+			created_utc = to_epoch(f.created_at),
+		},
+	}
+end
+
+--- Wrap an array of Things in a Listing envelope.
+-- @tparam table children array of serialized Things
+-- @tparam[opt] table opts { after = fullname|nil, before = fullname|nil }
+-- @treturn table
+function M.listing(children, opts)
+	opts = opts or {}
+	return {
+		kind = "Listing",
+		data = {
+			after = opts.after,
+			before = opts.before,
+			dist = #children,
+			children = children,
+		},
+	}
+end
+
+-- Clamp a requested limit to [1, 100] (Reddit's ceiling), default 25.
+local function clamp_limit(raw)
+	local n = tonumber(raw) or 25
+	return math.max(1, math.min(100, math.floor(n)))
+end
+
+--- Cursor-paginate an array of listing rows (each with a numeric `.id`) by
+-- Reddit `after`/`before` fullnames and `limit`. Returns the page of rows plus
+-- the fullnames to use for the next/previous page (nil when at an edge).
+-- @tparam table rows ordered rows
+-- @tparam table params request params ({ after, before, limit })
+-- @tparam string kind the rows' kind ("link" | "comment" | ...) for fullnames
+-- @treturn table page rows
+-- @treturn string|nil after fullname
+-- @treturn string|nil before fullname
+function M.paginate(rows, params, kind)
+	local limit = clamp_limit(params.limit)
+
+	-- Locate the cursor row by its fullname's numeric id.
+	local function index_of(name)
+		local _, id = M.parse_fullname(name)
+		if not id then
+			return nil
+		end
+		for i, r in ipairs(rows) do
+			if tonumber(r.id) == id then
+				return i
+			end
+		end
+		return nil
+	end
+
+	local start = 1
+	local after_idx = params.after and index_of(params.after)
+	if after_idx then
+		start = after_idx + 1
+	elseif params.before then
+		local before_idx = index_of(params.before)
+		if before_idx then
+			start = math.max(1, before_idx - limit)
+		end
+	end
+
+	local page = {}
+	for i = start, math.min(#rows, start + limit - 1) do
+		page[#page + 1] = rows[i]
+	end
+
+	local last = page[#page]
+	local first = page[1]
+	local more_after = last and (start + #page - 1) < #rows
+	local after = more_after and M.fullname(kind, last.id) or nil
+	local before = (start > 1 and first) and M.fullname(kind, first.id) or nil
+	return page, after, before
+end
+
+return M

--- a/app/src/utils/uuid.lua
+++ b/app/src/utils/uuid.lua
@@ -1,0 +1,79 @@
+--- RFC-4122 v4 UUIDs for the API's stable external ids
+-- @module utils.uuid
+--
+-- The API exposes a `public_id` (uuid) per row so callers reference an opaque,
+-- stable identifier instead of the guessable auto-increment `id`. UUIDs are
+-- minted once and stored (see migration [109] / utils.api_serialize), so they
+-- must be stable across calls -- generating one on every read would not be.
+--
+-- Source of randomness, in order of preference:
+--   1. sqlean's `uuid4()` SQL function, when the extension bundle is loaded onto
+--      Lapis's connection (the production/Docker path -- "use sqlean wherever
+--      possible"). See docs/sqlean-plan.md, which earmarked `uuid` for the API.
+--   2. openssl's CSPRNG (luaossl, already shipped for utils.token), formatted as
+--      a v4 UUID -- the path the test suite and `lapis migrate` take, since the
+--      sqlean `.so` is not loaded there.
+--   3. math.random, only if neither is available, so callers never crash.
+
+local M = {}
+
+-- Format 16 raw bytes as a canonical v4 UUID string, stamping the version
+-- (nibble 13 -> 4) and variant (nibble 17 -> 8..b) bits per RFC 4122.
+local function format_v4(bytes)
+	local b = { string.byte(bytes, 1, 16) }
+	b[7] = (b[7] % 16) + 0x40 -- version 4
+	b[9] = (b[9] % 64) + 0x80 -- variant 10xx
+	local hex = {}
+	for i = 1, 16 do
+		hex[i] = string.format("%02x", b[i])
+	end
+	return table.concat({
+		table.concat(hex, "", 1, 4),
+		table.concat(hex, "", 5, 6),
+		table.concat(hex, "", 7, 8),
+		table.concat(hex, "", 9, 10),
+		table.concat(hex, "", 11, 16),
+	}, "-")
+end
+
+-- sqlean's uuid4(), if the extension is loaded onto Lapis's connection. Returns
+-- the string or nil (never raises) so we fall through to the openssl path.
+local function from_sqlean()
+	if not require("src.utils.sqlite_ext").load() then
+		return nil
+	end
+	local ok, rows = pcall(require("lapis.db").select, "uuid4() AS u")
+	if ok and rows and rows[1] and type(rows[1].u) == "string" and #rows[1].u == 36 then
+		return rows[1].u
+	end
+	return nil
+end
+
+-- 16 CSPRNG bytes from openssl, formatted as a v4 UUID, or nil if luaossl is
+-- unavailable (e.g. the native lint loop).
+local function from_openssl()
+	local ok, rand = pcall(require, "openssl.rand")
+	if not ok then
+		return nil
+	end
+	return format_v4(rand.bytes(16))
+end
+
+-- Last-resort fallback: 16 math.random bytes. No CSPRNG guarantee, but still a
+-- well-formed, unique-enough v4 string so the column never goes unfilled.
+local function from_math()
+	local bytes = {}
+	for i = 1, 16 do
+		bytes[i] = string.char(math.random(0, 255))
+	end
+	return format_v4(table.concat(bytes))
+end
+
+--- Generate a fresh v4 UUID string (36 chars, lowercase, hyphenated).
+-- Never raises.
+-- @treturn string
+function M.generate()
+	return from_sqlean() or from_openssl() or from_math()
+end
+
+return M


### PR DESCRIPTION
Implements the deferred **API** phase from `TODO.md`: turns the disabled ~150-endpoint stub in `src/api.lua` into a real, enabled JSON API, leaning on sqlite/sqlean/lapis features throughout.

## What's here
- **Serializer** (`utils/api_serialize`): Reddit "Thing" envelopes (`t1`/`t2`/`t3`/`t5`) + `Listing`, base36 ids + `t?_<id>` fullnames, fullname parsing, cursor pagination (`after`/`before`/`limit`), and an opaque stable `uuid`.
- **Stable external ids (sqlean `uuid`)**: `utils/uuid` mints v4 UUIDs preferring sqlean `uuid4()`, falling back to `openssl.rand` so the test suite / `lapis migrate` (no `.so`) still work. Migration `[109]` adds a backfilled, unique `public_id` to `posts`/`comments`/`users`/`forum`.
- **Routes** (all under `/api/`, no collision with the HTML app):
  - *Reads:* `me`, `me/karma`, `me/saved`, `listing(/:sort)`, `r/:sub(/:sort)`, `r/:sub/about`, `comments/:id` (link + nested comment tree), `info?id=`, `search` (FTS5), `subreddits(/:where)`, `subreddits/search`, `user/:name/about`, `username_available`. Sorts/time-windows/search reuse `utils/sort`, `utils/timewindow`, `Posts:search`.
  - *Writes* (session + global CSRF filter): `vote` (new explicit `Votes:set`), `save`/`unsave`, `hide`/`unhide`, `subscribe`, `submit`, `comment`, `del`, `editusertext` — each enforcing the same spam / rate-limit / approval-queue / ownership rules as the web actions.

## Verification (in the `lapis-archlinux-itchio` Docker image)
- **274 specs pass** (0 failures / 0 errors), incl. new `app/spec/api_spec.lua`.
- **luacheck** 0/0; **stylua --check app** clean.
- **Coverage 86.31%** (gate 80%); `api.lua` no longer excluded from luacov.

## Backlog (not in this slice)
OAuth **bearer-token** auth (writes currently reuse the browser session + CSRF), and Reddit surfaces with no backing data (multis, wiki, modmail, gold, friends, trophies, prefs, captcha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)