### PR TITLE
test(api): broaden API coverage (error paths, serializer, uuid)

### DIFF
--- a/app/spec/api_serialize_spec.lua
+++ b/app/spec/api_serialize_spec.lua
@@ -1,0 +1,200 @@
+--- Unit spec for the API serializer (utils/api_serialize): base36 fullnames,
+--- cursor pagination, and the Thing/Listing shaping for each kind.
+
+local use_test_env = require("lapis.spec").use_test_env
+
+describe("api_serialize", function()
+	use_test_env()
+
+	local S = require("src.utils.api_serialize")
+	local Users = require("models.users")
+	local Forum = require("src.models.forum")
+	local Posts = require("src.models.posts")
+	local Votes = require("src.models.votes")
+
+	describe("base36 / fullnames", function()
+		it("round-trips base36", function()
+			for _, n in ipairs({ 0, 1, 35, 36, 42, 1000, 123456789 }) do
+				assert.same(n, S.from_base36(S.base36(n)))
+			end
+			assert.same("16", S.base36(42))
+		end)
+
+		it("builds and parses fullnames for every kind", function()
+			local cases = {
+				{ "link", "posts" },
+				{ "comment", "comments" },
+				{ "account", "users" },
+				{ "subreddit", "forum" },
+			}
+			for _, c in ipairs(cases) do
+				local name = S.fullname(c[1], 42)
+				local tbl, id = S.parse_fullname(name)
+				assert.same(c[2], tbl)
+				assert.same(42, id)
+			end
+		end)
+
+		it("rejects malformed fullnames", function()
+			assert.is_nil(S.parse_fullname("garbage"))
+			assert.is_nil(S.parse_fullname("t9_5")) -- unknown prefix
+			assert.is_nil(S.parse_fullname("t3_!!")) -- bad base36
+			assert.is_nil(S.parse_fullname(nil))
+			assert.is_nil(S.from_base36("!!"))
+			assert.is_nil(S.from_base36(""))
+		end)
+	end)
+
+	describe("paginate / listing", function()
+		local rows = {}
+		for i = 1, 150 do
+			rows[i] = { id = i }
+		end
+
+		it("defaults to 25 and exposes an after cursor", function()
+			local page, after, before = S.paginate(rows, {}, "link")
+			assert.same(25, #page)
+			assert.same(S.fullname("link", 25), after)
+			assert.is_nil(before)
+		end)
+
+		it("caps the limit at 100", function()
+			local page = S.paginate(rows, { limit = 500 }, "link")
+			assert.same(100, #page)
+		end)
+
+		it("advances past an after cursor and sets before", function()
+			local after = S.fullname("link", 25)
+			local page, next_after, before = S.paginate(rows, { limit = 5, after = after }, "link")
+			assert.same(26, page[1].id)
+			assert.same(5, #page)
+			assert.same(S.fullname("link", 26), before)
+			assert.same(S.fullname("link", 30), next_after)
+		end)
+
+		it("returns no after cursor on the last page", function()
+			local small = { { id = 1 }, { id = 2 } }
+			local _, after = S.paginate(small, { limit = 10 }, "link")
+			assert.is_nil(after)
+		end)
+
+		it("wraps children in a Listing envelope", function()
+			local l = S.listing({ { kind = "t3" }, { kind = "t3" } }, { after = "t3_2" })
+			assert.same("Listing", l.kind)
+			assert.same(2, l.data.dist)
+			assert.same("t3_2", l.data.after)
+		end)
+	end)
+
+	describe("Thing shaping", function()
+		local demo, sub, post
+
+		setup(function()
+			require("spec.schema_helper")()
+			demo = Users:create({
+				user_name = "serdemo",
+				user_pass = "password",
+				user_email = "s@e.com",
+			})
+			sub = Forum:create({ name = "sersub", creator_id = demo.id, description = "ser" })
+			post = Posts:create({
+				user_id = demo.id,
+				sub_id = sub.id,
+				title = "Ser Post",
+				url = "https://ser.example/a",
+			})
+		end)
+
+		it("shapes a link from an enriched row", function()
+			local t = S.link({
+				id = post.id,
+				title = "T",
+				upvotes = 3,
+				downvotes = 1,
+				author = "serdemo",
+				subreddit = "sersub",
+				num_comments = 2,
+				is_self = 0,
+				created_at = "2024-01-01 00:00:00",
+			})
+			assert.same("t3", t.kind)
+			assert.same(2, t.data.score)
+			assert.same(3, t.data.ups)
+			assert.same(2, t.data.num_comments)
+			assert.is_false(t.data.is_self)
+		end)
+
+		it("shapes a link from a bare row (vote/author/sub fallback)", function()
+			Votes:set(demo.id, post.id, nil, 1)
+			local t = S.link(Posts:find(post.id))
+			assert.same("t3", t.kind)
+			assert.same("serdemo", t.data.author)
+			assert.same("sersub", t.data.subreddit)
+			assert.same(1, t.data.ups)
+		end)
+
+		it("shapes a comment, blanking a deleted one", function()
+			local live = S.comment({
+				id = 1,
+				post_id = post.id,
+				body = "hi",
+				author = "serdemo",
+				subreddit = "sersub",
+				upvotes = 2,
+				downvotes = 0,
+				deleted = 0,
+			})
+			assert.same("t1", live.kind)
+			assert.same("hi", live.data.body)
+			assert.same(2, live.data.score)
+
+			local dead = S.comment({
+				id = 2,
+				post_id = post.id,
+				body = "secret",
+				author = "serdemo",
+				subreddit = "sersub",
+				deleted = 1,
+			})
+			assert.same("[deleted]", dead.data.body)
+			assert.same("[deleted]", dead.data.author)
+		end)
+
+		it("shapes an account", function()
+			local t = S.account(Users:find(demo.id))
+			assert.same("t2", t.kind)
+			assert.same("serdemo", t.data.name)
+			assert.same(S.fullname("account", demo.id), t.data.fullname)
+			assert.is_number(t.data.total_karma)
+		end)
+
+		it("shapes a subreddit, and one without an id", function()
+			local t = S.subreddit(Forum:find(sub.id))
+			assert.same("t5", t.kind)
+			assert.same("sersub", t.data.display_name)
+			assert.same("r/sersub", t.data.display_name_prefixed)
+			assert.is_number(t.data.subscribers)
+
+			-- A projection row without `id` (e.g. Forum:search) degrades gracefully.
+			local bare = S.subreddit({ name = "x", description = "d", subscribers = 0 })
+			assert.same("x", bare.data.display_name)
+			assert.is_nil(bare.data.id)
+		end)
+
+		it("mints a stable public_id and re-reads it", function()
+			local fresh = Posts:create({
+				user_id = demo.id,
+				sub_id = sub.id,
+				title = "uuid post",
+				url = "https://u.example",
+			})
+			-- A row without public_id (a listing projection): first call mints,
+			-- second re-reads the stored value -- both must agree.
+			local u1 = S.ensure_public_id("posts", { id = fresh.id })
+			local u2 = S.ensure_public_id("posts", { id = fresh.id })
+			assert.same(36, #u1)
+			assert.same(u1, u2)
+			assert.same(u1, Posts:find(fresh.id).public_id)
+		end)
+	end)
+end)

--- a/app/spec/api_spec.lua
+++ b/app/spec/api_spec.lua
@@ -52,16 +52,20 @@ describe("api", function()
 		return status, cjson.decode(body)
 	end
 
-	local sub, post, comment, demo
+	local sub, post, comment, demo, mod
 
 	setup(function()
 		require("spec.schema_helper")()
 		demo =
 			Users:create({ user_name = "apidemo", user_pass = "password", user_email = "a@e.com" })
+		-- A second moderator so post-creating error/edge tests don't eat into
+		-- demo's per-user post rate-limit budget (10 / 600s).
+		mod = Users:create({ user_name = "apimod", user_pass = "password", user_email = "m@e.com" })
 		sub = Forum:create({ name = "apisub", creator_id = demo.id, description = "API sub" })
-		-- Make the author a moderator so submit/comment posts aren't held in the
+		-- Make the authors moderators so submit/comment posts aren't held in the
 		-- new-user approval queue (mirrors integration_spec's flair_user).
 		Forum:add_moderator(sub.id, demo.id)
+		Forum:add_moderator(sub.id, mod.id)
 		post = Posts:create({
 			user_id = demo.id,
 			sub_id = sub.id,
@@ -305,6 +309,221 @@ describe("api", function()
 			assert.same("new body", Posts:find(p.id).body)
 			assert.same(200, (POST("/api/del", { id = fn }, "apidemo")))
 			assert.same(1, tonumber(Posts:find(p.id).deleted))
+		end)
+	end)
+
+	describe("index + not-found responses", function()
+		it("serves a friendly /api index", function()
+			local status, json = body_of("/api")
+			assert.same(200, status)
+			assert.truthy(json.name)
+		end)
+
+		it("404s an unknown subreddit about", function()
+			assert.same(404, (GET("/api/r/nope/about")))
+		end)
+
+		it("404s an unknown user", function()
+			assert.same(404, (GET("/api/user/ghost/about")))
+		end)
+
+		it("404s an unknown post's comments", function()
+			assert.same(404, (GET("/api/comments/999999")))
+		end)
+
+		it("400s username_available without a user", function()
+			assert.same(400, (GET("/api/username_available")))
+		end)
+
+		it("401s saved when logged out", function()
+			assert.same(401, (GET("/api/me/saved")))
+		end)
+	end)
+
+	describe("vote edge cases (auth)", function()
+		it("casts and clears a comment vote", function()
+			local fn = S.fullname("comment", comment.id)
+			POST("/api/vote", { id = fn, dir = 1 }, "apidemo")
+			assert.same(1, Votes:comment_score(comment.id))
+			POST("/api/vote", { id = fn, dir = 0 }, "apidemo")
+			assert.same(0, Votes:comment_score(comment.id))
+		end)
+
+		it("400s a non-votable thing kind", function()
+			assert.same(
+				400,
+				(POST("/api/vote", { id = S.fullname("subreddit", sub.id), dir = 1 }, "apidemo"))
+			)
+		end)
+
+		it("404s a vote on a missing post", function()
+			assert.same(
+				404,
+				(POST("/api/vote", { id = S.fullname("link", 999999), dir = 1 }, "apidemo"))
+			)
+		end)
+	end)
+
+	describe("save / subscribe edge cases (auth)", function()
+		it("400s save of a non-link thing", function()
+			assert.same(
+				400,
+				(POST("/api/save", { id = S.fullname("comment", comment.id) }, "apidemo"))
+			)
+		end)
+
+		it("404s save of a missing post", function()
+			assert.same(404, (POST("/api/save", { id = S.fullname("link", 999999) }, "apidemo")))
+		end)
+
+		it("404s subscribe to an unknown subreddit", function()
+			assert.same(
+				404,
+				(POST("/api/subscribe", { sr_name = "nope", action = "sub" }, "apidemo"))
+			)
+		end)
+	end)
+
+	describe("submit / comment edge cases (auth)", function()
+		it("401s submit when logged out", function()
+			assert.same(401, (POST("/api/submit", { sr = "apisub", title = "x", text = "y" })))
+		end)
+
+		it("404s submit to an unknown subreddit", function()
+			assert.same(
+				404,
+				(POST("/api/submit", { sr = "nope", title = "x", text = "y" }, "apidemo"))
+			)
+		end)
+
+		it("400s submit with neither url nor text", function()
+			assert.same(
+				400,
+				(POST("/api/submit", { sr = "apisub", kind = "link", title = "x" }, "apimod"))
+			)
+		end)
+
+		it("submits a link post", function()
+			local status, json = body_of_post(POST("/api/submit", {
+				sr = "apisub",
+				kind = "link",
+				title = "API link post",
+				url = "https://link.example/a",
+			}, "apimod"))
+			assert.same(201, status)
+			assert.same("t3", json.thing.kind)
+			assert.is_false(json.thing.data.is_self)
+			assert.same("https://link.example/a", json.thing.data.url)
+		end)
+
+		it("401s comment when logged out", function()
+			assert.same(
+				401,
+				(POST("/api/comment", { parent = S.fullname("link", post.id), text = "x" }))
+			)
+		end)
+
+		it("404s comment on a missing parent", function()
+			assert.same(
+				404,
+				(
+					POST(
+						"/api/comment",
+						{ parent = S.fullname("link", 999999), text = "x" },
+						"apidemo"
+					)
+				)
+			)
+		end)
+
+		it("403s comment on a locked thread", function()
+			local locked = Posts:create({
+				user_id = mod.id,
+				sub_id = sub.id,
+				title = "locked thread",
+				url = "https://locked.example",
+			})
+			locked:update({ comments_locked = 1 })
+			assert.same(
+				403,
+				(
+					POST(
+						"/api/comment",
+						{ parent = S.fullname("link", locked.id), text = "hi" },
+						"apidemo"
+					)
+				)
+			)
+		end)
+
+		it("replies to a comment (parent_id is a t1 fullname)", function()
+			local status, json = body_of_post(POST("/api/comment", {
+				parent = S.fullname("comment", comment.id),
+				text = "a nested api reply",
+			}, "apidemo"))
+			assert.same(201, status)
+			assert.same(S.fullname("comment", comment.id), json.thing.data.parent_id)
+		end)
+	end)
+
+	describe("del / editusertext ownership (auth)", function()
+		it("is a no-op deleting someone else's post", function()
+			assert.same(200, (POST("/api/del", { id = S.fullname("link", post.id) }, "apimod")))
+			assert.not_same(1, tonumber(Posts:find(post.id).deleted))
+		end)
+
+		it("400s del of an unknown thing id", function()
+			assert.same(400, (POST("/api/del", { id = "garbage" }, "apidemo")))
+		end)
+
+		it("403s editing someone else's post", function()
+			assert.same(
+				403,
+				(
+					POST(
+						"/api/editusertext",
+						{ thing_id = S.fullname("link", post.id), text = "x" },
+						"apimod"
+					)
+				)
+			)
+		end)
+
+		it("422s editing a non-self (link) post", function()
+			assert.same(
+				422,
+				(
+					POST(
+						"/api/editusertext",
+						{ thing_id = S.fullname("link", post.id), text = "x" },
+						"apidemo"
+					)
+				)
+			)
+		end)
+
+		it("edits your own comment", function()
+			local c =
+				Comments:create({ post_id = post.id, user_id = demo.id, body = "editable comment" })
+			assert.same(
+				200,
+				(
+					POST(
+						"/api/editusertext",
+						{ thing_id = S.fullname("comment", c.id), text = "edited comment" },
+						"apidemo"
+					)
+				)
+			)
+			assert.same("edited comment", Comments:find(c.id).body)
+		end)
+	end)
+
+	describe("pagination", function()
+		it("limits the page and exposes an after cursor", function()
+			local _, json = body_of("/api/listing?limit=1")
+			assert.same(1, #json.data.children)
+			assert.truthy(json.data.after)
 		end)
 	end)
 end)

--- a/app/spec/uuid_spec.lua
+++ b/app/spec/uuid_spec.lua
@@ -1,0 +1,49 @@
+--- Unit spec for utils/uuid: the API's stable external-id generator.
+
+local use_test_env = require("lapis.spec").use_test_env
+
+describe("uuid", function()
+	-- Loads sqlite_ext + lapis.db so the preferred sqlean uuid4() path is exercised
+	-- when the extension is available (with the openssl/math fallbacks otherwise).
+	use_test_env()
+
+	local uuid = require("src.utils.uuid")
+
+	local V4 = "^%x%x%x%x%x%x%x%x%-%x%x%x%x%-4%x%x%x%-[89ab]%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x$"
+
+	it("generates a canonical v4 UUID", function()
+		local u = uuid.generate()
+		assert.same(36, #u)
+		assert.truthy(u:match(V4), "not a v4 uuid: " .. u)
+	end)
+
+	it("generates distinct values", function()
+		local seen = {}
+		for _ = 1, 25 do
+			local u = uuid.generate()
+			assert.is_nil(seen[u])
+			seen[u] = true
+		end
+	end)
+
+	it("falls back to a formatted v4 when sqlean is unavailable", function()
+		-- Force the non-sqlean path (test/lint envs without the .so) by stubbing
+		-- the extension loader to report "not loaded", then re-requiring uuid.
+		local saved_ext = package.loaded["src.utils.sqlite_ext"]
+		package.loaded["src.utils.sqlite_ext"] = {
+			load = function()
+				return false
+			end,
+		}
+		package.loaded["src.utils.uuid"] = nil
+		local fresh = require("src.utils.uuid")
+
+		local u = fresh.generate()
+
+		package.loaded["src.utils.sqlite_ext"] = saved_ext
+		package.loaded["src.utils.uuid"] = uuid
+
+		assert.same(36, #u)
+		assert.truthy(u:match(V4), "not a v4 uuid: " .. u)
+	end)
+end)


### PR DESCRIPTION
Follow-up to #12: adds tests for the JSON API's error/edge paths and two focused unit specs.

## What's here
- **`api_spec.lua`** — error/edge cases across `vote`, `save`, `subscribe`, `submit`, `comment`, `del`, `editusertext` (401/403/404/400/422), comment replies + locked threads, the `/api` index, and cursor pagination.
- **`api_serialize_spec.lua`** (new) — base36 round-trips + fullname parsing, cursor pagination (default 25, cap 100, after/before), and Thing shaping for link/comment/account/subreddit incl. bare-row fallbacks, a deleted comment, an id-less subreddit row, and stable `public_id` minting.
- **`uuid_spec.lua`** (new) — v4 format + uniqueness, plus the non-sqlean (openssl/format) fallback path.

## Verification (Docker `lapis-archlinux-itchio` image)
- **317 specs pass** (0 failures / 0 errors).
- **luacheck** 0/0; **stylua --check app** clean.
- **Coverage 88.09%** (gate 80%): `api.lua` 77.5%→89.1%, `api_serialize` 91.4%→96.8%, `uuid` 25.8%→80.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)