### PR TITLE
docs: document the JSON API (TODO, CHANGELOG, README)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
 This run took the PoC from a rough, non-booting prototype to a running,
 test-covered Reddit clone. Highlights, newest first:
 
+### Reddit-flavoured JSON API (`/api`) + sqlean `uuid` stable ids
+- **The API is real and enabled.** `src/api.lua` went from ~150 disabled stub
+  endpoints to a working JSON API, wired into `app.lua`. Everything lives under
+  `/api/` so it never collides with the HTML app's `/(:sort)` / `/r/...` routes,
+  and every response is a Reddit "Thing" (`t1` comment / `t2` account / `t3`
+  link / `t5` subreddit) or `Listing`, shaped by `utils/api_serialize` (base36
+  ids + `t?_<id>` fullnames, cursor pagination via `after`/`before`/`limit`).
+  All reads and writes go through the existing models — nothing is re-queried by
+  hand where a model method already does it.
+  - **Reads:** `/api/v1/me`, `/api/v1/me/karma`, `/api/me/saved`,
+    `/api/listing(/:sort)`, `/api/r/:sub(/:sort)`, `/api/r/:sub/about`,
+    `/api/comments/:id` (link + nested comment tree), `/api/info?id=`,
+    `/api/search`, `/api/subreddits(/:where)`, `/api/subreddits/search`,
+    `/api/user/:name/about`, `/api/username_available`. Sorts reuse
+    `utils/sort`, `?t=` reuses `utils/timewindow`, search reuses the FTS5 +
+    fuzzy `Posts:search`.
+  - **Writes** (session + the global CSRF filter, also accepts an
+    `X-Csrf-Token` header): `/api/vote` (a new explicit `Votes:set`),
+    `/api/save`/`unsave`, `/api/hide`/`unhide`, `/api/subscribe`, `/api/submit`,
+    `/api/comment`, `/api/del`, `/api/editusertext` — each enforcing the same
+    spam / rate-limit / approval-queue / ownership rules as the web actions.
+- **sqlean `uuid` adopted for stable external ids** (the module
+  `docs/sqlean-plan.md` earmarked for this phase). Every public-facing row now
+  carries an opaque `public_id` UUID (migration `[109]` on
+  `posts`/`comments`/`users`/`forum`, backfilled), exposed as a Thing's `uuid`.
+  `utils/uuid` mints v4 UUIDs preferring sqlean's `uuid4()` and falling back to
+  `openssl.rand` so the test suite and `lapis migrate` (no `.so` loaded) still
+  work; ids are minted lazily on first serialization so listing projections that
+  don't select the column don't clobber a stored value.
+- **Out of scope for this slice:** OAuth **bearer-token** auth (API writes reuse
+  the browser's session + CSRF for now), and the Reddit surfaces with no backing
+  data (multis, wiki, modmail, gold/awards, friends, trophies, prefs, captcha).
+  Covered by `api_spec` + `api_serialize_spec` + `uuid_spec`. (317 specs.)
+
 ### Stored `posts.domain` + sqlean `fuzzy`/`regexp` put to work
 - **`posts.domain` is now a real, indexed column** (migration `[108]`), the
   normalized link host computed once at write time by `Posts:create` (via

--- a/README.md
+++ b/README.md
@@ -22,10 +22,36 @@ A better social link-sharing site.
   - [ ] `/login`, `/logout`, `/password`
   - [ ] `prefs`, `settings`
 - [x] RSS feed import/sync (per-subreddit; live importer + in-process scheduler)
-- [ ] API (https://reddit.com/dev/api/)
+- [x] API ([Reddit-flavoured JSON](https://reddit.com/dev/api/); see below)
 
 See [`TODO.md`](TODO.md) for the living roadmap, including the forum-generalization
 work (RBAC, admin panel, tags, @mentions, reputation, …).
+
+## API
+
+A Reddit-flavoured JSON API lives under `/api`. Responses are Reddit "Thing"
+envelopes — `{ "kind": "t3", "data": { … } }` for a link (`t1` comment, `t2`
+account, `t5` subreddit) — and `{ "kind": "Listing", "data": { "children": […],
+"after": …, "before": … } }` for a page. Each Thing carries Reddit's base36 `id`
+/ `t?_<id>` fullname plus an opaque, stable `uuid` (a `public_id` minted with
+sqlean's `uuid4()`).
+
+- **Reads** (public): `GET /api/listing(/:sort)`, `/api/r/:sub(/:sort)`,
+  `/api/r/:sub/about`, `/api/comments/:id` (link + nested comment tree),
+  `/api/info?id=t3_…,t1_…`, `/api/search?q=`, `/api/subreddits(/:where)`,
+  `/api/subreddits/search?q=`, `/api/user/:name/about`,
+  `/api/username_available?user=`. Sorts (`hot`/`new`/`top`/`best`/
+  `controversial`/`rising`), `?t=` time windows, and `?after`/`?before`/`?limit`
+  cursor pagination are supported.
+- **Account** (logged in): `GET /api/v1/me`, `/api/v1/me/karma`,
+  `/api/me/saved`.
+- **Writes** (logged in): `POST /api/vote` `{id, dir}`, `/api/save`,
+  `/api/unsave`, `/api/hide`, `/api/unhide`, `/api/subscribe`, `/api/submit`,
+  `/api/comment`, `/api/del`, `/api/editusertext`.
+
+Writes authenticate with the browser session and the same CSRF token as the web
+forms (sent as the `csrf_token` field or an `X-Csrf-Token` header); OAuth
+bearer-token auth is a future addition.
 
 ## Development
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,14 +8,15 @@ hot/new/top/controversial/best/rising and `?t=` time windows + pagination;
 full-text search (FTS5); open a post; vote on posts & comments; submit
 link/self posts; post threaded comments/replies with Markdown; edit/delete own
 posts & comments; subscribe/unsubscribe; saved/hidden posts; user profiles +
-karma; reply notifications (`/inbox`); RSS in/out feeds; bcrypt + CSRF auth.
+karma; reply notifications (`/inbox`); RSS in/out feeds; bcrypt + CSRF auth; a
+Reddit-flavoured JSON API under `/api`.
 
 Forum-generalization layer (all shipped): role-based moderation via a privilege
 matrix (`owner`/`moderator`/`member` + site `admin`); an Admin Control Panel
 (`/admin`); cached user reputation + trust levels; a new-user post-approval
 queue (`/r/:sub/queue`) with rate limiting; tags (`/t/:tag`); `@mentions`;
 accept-answer Q&A mode; and OAuth login. The Docker image boots and serves;
-**274-spec Busted suite + luacheck pass**.
+**317-spec Busted suite + luacheck pass**.
 
 ## Next up
 - [x] **Auth/password hardening** (issue #6): bcrypt password hashing
@@ -280,7 +281,7 @@ dependency-driven (foundations first); full plan in
     `-- TODO rename` marker.
 
 ## Test & quality
-- **274 specs** (model/SQL + full HTTP integration via `simulate_request`), luacov
+- **317 specs** (model/SQL + full HTTP integration via `simulate_request`), luacov
   coverage, and **luacheck** (0 warnings / 0 errors).
 - CI per push: super-linter, **stylua** (`--check app`), **luacheck**
   (`luacheck app`), **busted + luacov** (with an 80% coverage gate), and a


### PR DESCRIPTION
Docs follow-up to #12 / #13 — no code changes.

- **README**: marks the API roadmap item done and adds an `## API` section (Thing/Listing envelope shape, the read / account / write endpoints, sort + pagination params, and the session + CSRF auth note).
- **CHANGELOG**: new "newest first" entry covering the `/api` JSON API and the sqlean `uuid` stable-id adoption.
- **TODO**: notes the API in "Working now" and bumps the suite count to 317 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)